### PR TITLE
fix possible unstake problem

### DIFF
--- a/farm-staking/farm-staking-proxy/Cargo.toml
+++ b/farm-staking/farm-staking-proxy/Cargo.toml
@@ -51,6 +51,9 @@ path = "../../common/traits/fixed-supply-token"
 [dependencies.mergeable]
 path = "../../common/traits/mergeable"
 
+[dependencies.unwrappable]
+path = "../../common/traits/unwrappable"
+
 [dependencies.sc_whitelist_module]
 path = "../../common/modules/sc_whitelist_module"
 

--- a/farm-staking/farm-staking-proxy/tests/composed_pos_test.rs
+++ b/farm-staking/farm-staking-proxy/tests/composed_pos_test.rs
@@ -123,7 +123,7 @@ fn combine_metastaking_with_staking_pos_test() {
         Some(&DualYieldTokenAttributes::<DebugApi> {
             lp_farm_token_nonce: 2,
             lp_farm_token_amount: managed_biguint!(USER_TOTAL_LP_TOKENS),
-            staking_farm_token_nonce: 4,
+            staking_farm_token_nonce: 6,
             staking_farm_token_amount: managed_biguint!(expected_staking_token_amount),
             user_staking_farm_token_amount: managed_biguint!(composed_pos_full_amount),
         }),
@@ -329,7 +329,7 @@ fn combine_metastaking_with_staking_pos_partial_actions_test() {
         Some(&DualYieldTokenAttributes::<DebugApi> {
             lp_farm_token_nonce: 2,
             lp_farm_token_amount: managed_biguint!(USER_TOTAL_LP_TOKENS / 2),
-            staking_farm_token_nonce: 4,
+            staking_farm_token_nonce: 6,
             staking_farm_token_amount: managed_biguint!(expected_staking_token_amount / 2),
             user_staking_farm_token_amount: managed_biguint!(composed_pos_full_amount),
         }),


### PR DESCRIPTION
If user would try to unstake directly after merging, the transaction would fail, as we haven't created the full position with the "new value" yet (we were only doing it after a manual claim).

This fixes that issue by claiming with the full new value directly when merging.