### PR TITLE
fix wrong claim value

### DIFF
--- a/farm-staking/farm-staking-proxy/src/proxy_actions/claim.rs
+++ b/farm-staking/farm-staking-proxy/src/proxy_actions/claim.rs
@@ -31,7 +31,12 @@ pub trait ProxyClaimModule:
         let caller = self.blockchain().get_caller();
         let attributes: DualYieldTokenAttributes<Self::Api> =
             self.get_attributes_as_part_of_fixed_supply(&payment, &dual_yield_token_mapper);
-        let internal_claim_result = self.claim_dual_yield(&caller, opt_orig_caller, attributes);
+        let internal_claim_result = self.claim_dual_yield(
+            &caller,
+            opt_orig_caller,
+            attributes.get_total_staking_token_amount(),
+            attributes,
+        );
 
         let new_dual_yield_tokens = self.create_dual_yield_tokens(
             &dual_yield_token_mapper,
@@ -52,6 +57,7 @@ pub trait ProxyClaimModule:
         &self,
         caller: &ManagedAddress,
         opt_orig_caller: OptionalValue<ManagedAddress>,
+        staking_claim_amount: BigUint,
         attributes: DualYieldTokenAttributes<Self::Api>,
     ) -> InternalClaimResult<Self::Api> {
         let orig_caller = self.get_orig_caller_from_opt(caller, opt_orig_caller);
@@ -76,7 +82,7 @@ pub trait ProxyClaimModule:
             orig_caller,
             staking_farm_token_id,
             attributes.staking_farm_token_nonce,
-            attributes.staking_farm_token_amount,
+            staking_claim_amount,
             new_staking_farm_value,
         );
 

--- a/farm-staking/farm-staking-proxy/src/proxy_actions/merge_pos.rs
+++ b/farm-staking/farm-staking-proxy/src/proxy_actions/merge_pos.rs
@@ -39,12 +39,17 @@ pub trait ProxyMergePosModule:
         let caller = self.blockchain().get_caller();
         let staking_farm_rewards = self.claim_staking_rewards_before_merge(&caller, &payments);
 
+        let staking_amount_before_merge = attributes.get_total_staking_token_amount();
         for farm_staking_token in &payments {
             attributes.user_staking_farm_token_amount += &farm_staking_token.amount;
         }
 
-        let mut dual_yield_claim_result =
-            self.claim_dual_yield(&caller, OptionalValue::None, attributes);
+        let mut dual_yield_claim_result = self.claim_dual_yield(
+            &caller,
+            OptionalValue::None,
+            staking_amount_before_merge,
+            attributes,
+        );
         dual_yield_claim_result
             .staking_farm_rewards
             .merge_with(staking_farm_rewards);


### PR DESCRIPTION
Previously, claimDualYield would only claim rewards for the metastaking position, and not with the full combined position of metastaking + staking.