### PR TITLE
remove lkmex from locked token wrapper SC

### DIFF
--- a/energy-integration/energy-factory-mock/src/lib.rs
+++ b/energy-integration/energy-factory-mock/src/lib.rs
@@ -54,4 +54,7 @@ pub trait EnergyFactoryMock {
 
     #[storage_mapper("userEnergy")]
     fn user_energy(&self, user: &ManagedAddress) -> SingleValueMapper<Energy<Self::Api>>;
+
+    #[storage_mapper("lockedTokenId")]
+    fn locked_token(&self) -> NonFungibleTokenMapper;
 }

--- a/locked-asset/lkmex-transfer/src/energy_transfer.rs
+++ b/locked-asset/lkmex-transfer/src/energy_transfer.rs
@@ -1,6 +1,6 @@
 multiversx_sc::imports!();
 
-use common_structs::{OldLockedTokenAttributes, PaymentsVec};
+use common_structs::PaymentsVec;
 use energy_factory::locked_token_transfer::ProxyTrait as _;
 use energy_query::Energy;
 use simple_lock::locked_token::LockedTokenAttributes;
@@ -37,30 +37,6 @@ pub trait EnergyTransferModule:
         self.set_energy_in_factory(from_user, energy);
     }
 
-    fn deduct_old_token_energy_from_sender(
-        &self,
-        from_user: ManagedAddress,
-        tokens: &PaymentsVec<Self::Api>,
-    ) {
-        if self.blockchain().is_smart_contract(&from_user) {
-            return;
-        }
-
-        let current_epoch = self.blockchain().get_block_epoch();
-        let mut energy = self.get_energy_entry(&from_user);
-
-        for token in tokens {
-            let attributes: OldLockedTokenAttributes<Self::Api> =
-                self.decode_legacy_token(&token.token_identifier, token.token_nonce);
-            let epoch_amount_pairs = attributes.get_unlock_amounts_per_epoch(&token.amount);
-            for pair in epoch_amount_pairs.pairs {
-                energy.update_after_unlock_any(&pair.amount, pair.epoch, current_epoch);
-            }
-        }
-
-        self.set_energy_in_factory(from_user, energy);
-    }
-
     fn add_energy_to_destination(&self, to_user: ManagedAddress, tokens: &PaymentsVec<Self::Api>) {
         let current_epoch = self.blockchain().get_block_epoch();
         let mut energy = self.get_energy_entry(&to_user);
@@ -77,29 +53,6 @@ pub trait EnergyTransferModule:
                 let epoch_diff = current_epoch - attributes.unlock_epoch;
                 let simulated_deplete_amount = &token.amount * epoch_diff;
                 energy.remove_energy_raw(BigUint::zero(), simulated_deplete_amount);
-            }
-        }
-
-        self.set_energy_in_factory(to_user, energy);
-    }
-
-    fn add_old_token_energy_to_destination(
-        &self,
-        to_user: ManagedAddress,
-        tokens: &PaymentsVec<Self::Api>,
-    ) {
-        if self.blockchain().is_smart_contract(&to_user) {
-            return;
-        }
-
-        let current_epoch = self.blockchain().get_block_epoch();
-        let mut energy = self.get_energy_entry(&to_user);
-
-        for token in tokens {
-            let attributes = self.decode_legacy_token(&token.token_identifier, token.token_nonce);
-            let epoch_amount_pairs = attributes.get_unlock_amounts_per_epoch(&token.amount);
-            for pair in epoch_amount_pairs.pairs {
-                energy.add_after_token_lock(&pair.amount, pair.epoch, current_epoch);
             }
         }
 

--- a/locked-asset/locked-token-wrapper/elrond.json
+++ b/locked-asset/locked-token-wrapper/elrond.json
@@ -1,3 +1,0 @@
-{
-    "language": "rust"
-}

--- a/locked-asset/locked-token-wrapper/src/lib.rs
+++ b/locked-asset/locked-token-wrapper/src/lib.rs
@@ -15,22 +15,8 @@ pub trait LockedTokenWrapper:
     + legacy_token_decode_module::LegacyTokenDecodeModule
 {
     #[init]
-    fn init(
-        &self,
-        old_locked_token_id: TokenIdentifier,
-        new_locked_token_id: TokenIdentifier,
-        energy_factory_address: ManagedAddress,
-    ) {
-        self.require_valid_token_id(&old_locked_token_id);
-        self.require_valid_token_id(&new_locked_token_id);
+    fn init(&self, energy_factory_address: ManagedAddress) {
         self.require_sc_address(&energy_factory_address);
-
-        if self.old_locked_token().is_empty() {
-            self.old_locked_token().set_token_id(old_locked_token_id);
-        }
-        if self.locked_token().is_empty() {
-            self.locked_token().set_token_id(new_locked_token_id);
-        }
         self.energy_factory_address().set(&energy_factory_address);
     }
 
@@ -40,23 +26,15 @@ pub trait LockedTokenWrapper:
         let payment = self.call_value().single_esdt();
         let caller = self.blockchain().get_caller();
 
-        if payment.token_identifier == self.locked_token().get_token_id() {
-            self.deduct_energy_from_sender(
-                caller.clone(),
-                &ManagedVec::from_single_item(payment.clone()),
-            );
-
-            self.wrap_locked_token_and_send(&caller, payment)
-        } else if payment.token_identifier == self.old_locked_token().get_token_id() {
-            self.deduct_old_token_energy_from_sender(
-                caller.clone(),
-                &ManagedVec::from_single_item(payment.clone()),
-            );
-
-            self.wrap_locked_token_and_send(&caller, payment)
-        } else {
-            sc_panic!("Bad payment token");
-        }
+        require!(
+            payment.token_identifier == self.get_locked_token_id(),
+            "Bad payment tokens"
+        );
+        self.deduct_energy_from_sender(
+            caller.clone(),
+            &ManagedVec::from_single_item(payment.clone()),
+        );
+        self.wrap_locked_token_and_send(&caller, payment)
     }
 
     #[payable("*")]
@@ -71,14 +49,8 @@ pub trait LockedTokenWrapper:
         let payment = self.call_value().single_esdt();
         let original_locked_tokens = self.unwrap_locked_token(payment);
 
-        if original_locked_tokens.token_identifier == self.locked_token().get_token_id() {
+        if original_locked_tokens.token_identifier == self.get_locked_token_id() {
             self.add_energy_to_destination(
-                caller.clone(),
-                &ManagedVec::from_single_item(original_locked_tokens.clone()),
-            );
-        } else if original_locked_tokens.token_identifier == self.old_locked_token().get_token_id()
-        {
-            self.add_old_token_energy_to_destination(
                 caller.clone(),
                 &ManagedVec::from_single_item(original_locked_tokens.clone()),
             );

--- a/locked-asset/locked-token-wrapper/src/wrapped_token.rs
+++ b/locked-asset/locked-token-wrapper/src/wrapped_token.rs
@@ -105,14 +105,6 @@ pub trait WrappedTokenModule:
         )
     }
 
-    #[view(getLockedTokenId)]
-    #[storage_mapper("lockedTokenId")]
-    fn locked_token(&self) -> NonFungibleTokenMapper;
-
-    #[view(getOldLockedTokenId)]
-    #[storage_mapper("oldLockedTokenId")]
-    fn old_locked_token(&self) -> NonFungibleTokenMapper;
-
     #[view(getWrappedTokenId)]
     #[storage_mapper("wrappedTokenId")]
     fn wrapped_token(&self) -> NonFungibleTokenMapper;

--- a/locked-asset/locked-token-wrapper/tests/locked_token_wrapping_test.rs
+++ b/locked-asset/locked-token-wrapper/tests/locked_token_wrapping_test.rs
@@ -1,15 +1,10 @@
-use common_structs::{LockedAssetTokenAttributesEx, UnlockMilestoneEx, UnlockScheduleEx};
 use energy_factory_mock::EnergyFactoryMock;
 use energy_query::Energy;
-use legacy_token_decode_module::LOCKED_TOKEN_ACTIVATION_NONCE;
 use locked_token_wrapper::{
     wrapped_token::{WrappedTokenAttributes, WrappedTokenModule},
     LockedTokenWrapper,
 };
-use multiversx_sc::{
-    storage::mappers::StorageTokenWrapper,
-    types::{EsdtLocalRole, ManagedVec},
-};
+use multiversx_sc::{storage::mappers::StorageTokenWrapper, types::EsdtLocalRole};
 use multiversx_sc_scenario::{
     managed_address, managed_biguint, managed_token_id, managed_token_id_wrapped, rust_biguint,
     whitebox::BlockchainStateWrapper, DebugApi,
@@ -18,7 +13,6 @@ use simple_lock::locked_token::LockedTokenAttributes;
 
 static BASE_ASSET_TOKEN_ID: &[u8] = b"FREEEE-123456";
 static LOCKED_TOKEN_ID: &[u8] = b"LOCKED-123456";
-static LEGACY_LOCKED_TOKEN_ID: &[u8] = b"LEGACY-123456";
 static WRAPPED_TOKEN_ID: &[u8] = b"WRAPPED-123456";
 
 #[test]
@@ -46,11 +40,7 @@ fn token_wrap_unwrap_test() {
     // setup wrapping SC
     b_mock
         .execute_tx(&owner, &locked_token_wrapper, &rust_zero, |sc| {
-            sc.init(
-                managed_token_id!(LEGACY_LOCKED_TOKEN_ID),
-                managed_token_id!(LOCKED_TOKEN_ID),
-                managed_address!(energy_factory.address_ref()),
-            );
+            sc.init(managed_address!(energy_factory.address_ref()));
 
             sc.wrapped_token()
                 .set_token_id(managed_token_id!(WRAPPED_TOKEN_ID));
@@ -82,6 +72,9 @@ fn token_wrap_unwrap_test() {
 
     b_mock
         .execute_tx(&owner, &energy_factory, &rust_zero, |sc| {
+            sc.locked_token()
+                .set_token_id(managed_token_id!(LOCKED_TOKEN_ID));
+
             let energy = Energy::new(
                 (managed_biguint!(1_000) * 20u64).into(),
                 0,
@@ -185,14 +178,13 @@ fn token_wrap_unwrap_test() {
 }
 
 #[test]
-fn both_tokens_wrap_unwrap_test() {
+fn tokens_wrap_unwrap_test2() {
     let _ = DebugApi::dummy();
     let rust_zero = rust_biguint!(0);
 
     let mut b_mock = BlockchainStateWrapper::new();
     let owner = b_mock.create_user_account(&rust_zero);
     let first_user = b_mock.create_user_account(&rust_zero);
-    let second_user = b_mock.create_user_account(&rust_zero);
     let user_balance = 1_000u64;
     let energy_factory = b_mock.create_sc_account(
         &rust_zero,
@@ -210,11 +202,7 @@ fn both_tokens_wrap_unwrap_test() {
     // setup wrapping SC
     b_mock
         .execute_tx(&owner, &locked_token_wrapper, &rust_zero, |sc| {
-            sc.init(
-                managed_token_id!(LEGACY_LOCKED_TOKEN_ID),
-                managed_token_id!(LOCKED_TOKEN_ID),
-                managed_address!(energy_factory.address_ref()),
-            );
+            sc.init(managed_address!(energy_factory.address_ref()));
 
             sc.wrapped_token()
                 .set_token_id(managed_token_id!(WRAPPED_TOKEN_ID));
@@ -244,71 +232,22 @@ fn both_tokens_wrap_unwrap_test() {
         },
     );
 
-    let mut current_epoch = 1_441;
-    b_mock.set_block_epoch(current_epoch);
-
-    let first_unlock_epoch = 1_531;
-    let second_unlock_epoch = 1_621;
-    let third_unlock_epoch = 1_711;
-    let forth_unlock_epoch = 1_801;
-    let mut unlock_milestones = ManagedVec::<DebugApi, UnlockMilestoneEx>::new();
-    unlock_milestones.push(UnlockMilestoneEx {
-        unlock_percent: 20_000,
-        unlock_epoch: first_unlock_epoch,
-    });
-    unlock_milestones.push(UnlockMilestoneEx {
-        unlock_percent: 20_000,
-        unlock_epoch: second_unlock_epoch,
-    });
-    unlock_milestones.push(UnlockMilestoneEx {
-        unlock_percent: 20_000,
-        unlock_epoch: third_unlock_epoch,
-    });
-    unlock_milestones.push(UnlockMilestoneEx {
-        unlock_percent: 40_000,
-        unlock_epoch: forth_unlock_epoch,
-    });
-    let old_token_attributes = LockedAssetTokenAttributesEx {
-        is_merged: false,
-        unlock_schedule: UnlockScheduleEx { unlock_milestones },
-    };
-
-    b_mock.set_nft_balance(
-        &second_user,
-        LEGACY_LOCKED_TOKEN_ID,
-        LOCKED_TOKEN_ACTIVATION_NONCE + 1,
-        &rust_biguint!(user_balance),
-        &old_token_attributes,
-    );
-
-    let mut second_user_energy_amount = 0u64;
-    second_user_energy_amount +=
-        20_000 * user_balance * (first_unlock_epoch - current_epoch) / 100_000u64;
-    second_user_energy_amount +=
-        20_000 * user_balance * (second_unlock_epoch - current_epoch) / 100_000u64;
-    second_user_energy_amount +=
-        20_000 * user_balance * (third_unlock_epoch - current_epoch) / 100_000u64;
-    second_user_energy_amount +=
-        40_000 * user_balance * (forth_unlock_epoch - current_epoch) / 100_000u64;
-
     b_mock
         .execute_tx(&owner, &energy_factory, &rust_zero, |sc| {
-            let first_user_energy = Energy::new(
-                (managed_biguint!(user_balance) * first_user_unlock_epoch).into(),
+            sc.locked_token()
+                .set_token_id(managed_token_id!(LOCKED_TOKEN_ID));
+
+            let energy = Energy::new(
+                (managed_biguint!(1_000) * 1_700u64).into(),
                 0,
-                managed_biguint!(user_balance),
+                managed_biguint!(1_000),
             );
-            let second_user_energy = Energy::new(
-                (managed_biguint!(second_user_energy_amount)).into(),
-                current_epoch,
-                managed_biguint!(user_balance),
-            );
-            sc.user_energy(&managed_address!(&first_user))
-                .set(&first_user_energy);
-            sc.user_energy(&managed_address!(&second_user))
-                .set(&second_user_energy);
+            sc.user_energy(&managed_address!(&first_user)).set(&energy);
         })
         .assert_ok();
+
+    let mut current_epoch = 1_441;
+    b_mock.set_block_epoch(current_epoch);
 
     // wrap 500 tokens
     let user_half_balance = user_balance / 2;
@@ -318,19 +257,6 @@ fn both_tokens_wrap_unwrap_test() {
             &locked_token_wrapper,
             LOCKED_TOKEN_ID,
             1,
-            &rust_biguint!(user_half_balance),
-            |sc| {
-                let _ = sc.wrap_locked_token_endpoint();
-            },
-        )
-        .assert_ok();
-
-    b_mock
-        .execute_esdt_transfer(
-            &second_user,
-            &locked_token_wrapper,
-            LEGACY_LOCKED_TOKEN_ID,
-            LOCKED_TOKEN_ACTIVATION_NONCE + 1,
             &rust_biguint!(user_half_balance),
             |sc| {
                 let _ = sc.wrap_locked_token_endpoint();
@@ -349,17 +275,6 @@ fn both_tokens_wrap_unwrap_test() {
         }),
     );
 
-    b_mock.check_nft_balance(
-        &second_user,
-        WRAPPED_TOKEN_ID,
-        2,
-        &rust_biguint!(user_half_balance),
-        Some(&WrappedTokenAttributes::<DebugApi> {
-            locked_token_id: managed_token_id!(LEGACY_LOCKED_TOKEN_ID),
-            locked_token_nonce: LOCKED_TOKEN_ACTIVATION_NONCE + 1,
-        }),
-    );
-
     // check energy after wrap
     b_mock
         .execute_query(&energy_factory, |sc| {
@@ -370,18 +285,6 @@ fn both_tokens_wrap_unwrap_test() {
                 managed_biguint!(user_half_balance),
             );
             let actual_energy = sc.user_energy(&managed_address!(&first_user)).get();
-            assert_eq!(actual_energy, expected_energy);
-        })
-        .assert_ok();
-
-    b_mock
-        .execute_query(&energy_factory, |sc| {
-            let expected_energy = Energy::new(
-                (managed_biguint!(second_user_energy_amount / 2)).into(),
-                current_epoch,
-                managed_biguint!(user_half_balance),
-            );
-            let actual_energy = sc.user_energy(&managed_address!(&second_user)).get();
             assert_eq!(actual_energy, expected_energy);
         })
         .assert_ok();
@@ -404,19 +307,6 @@ fn both_tokens_wrap_unwrap_test() {
         )
         .assert_ok();
 
-    b_mock
-        .execute_esdt_transfer(
-            &second_user,
-            &locked_token_wrapper,
-            WRAPPED_TOKEN_ID,
-            2,
-            &rust_biguint!(user_half_balance),
-            |sc| {
-                let _ = sc.unwrap_locked_token_endpoint();
-            },
-        )
-        .assert_ok();
-
     // check balances
     b_mock.check_nft_balance(
         &first_user,
@@ -430,14 +320,6 @@ fn both_tokens_wrap_unwrap_test() {
         }),
     );
 
-    b_mock.check_nft_balance(
-        &second_user,
-        LEGACY_LOCKED_TOKEN_ID,
-        LOCKED_TOKEN_ACTIVATION_NONCE + 1,
-        &rust_biguint!(user_balance),
-        Some(&old_token_attributes),
-    );
-
     // check energy after unwrap
     b_mock
         .execute_query(&energy_factory, |sc| {
@@ -447,28 +329,6 @@ fn both_tokens_wrap_unwrap_test() {
                 managed_biguint!(user_balance),
             );
             let actual_energy = sc.user_energy(&managed_address!(&first_user)).get();
-            assert_eq!(actual_energy, expected_energy);
-        })
-        .assert_ok();
-
-    let mut final_second_user_energy_amount = 0u64;
-    final_second_user_energy_amount +=
-        20_000 * user_balance * (first_unlock_epoch - current_epoch) / 100_000u64;
-    final_second_user_energy_amount +=
-        20_000 * user_balance * (second_unlock_epoch - current_epoch) / 100_000u64;
-    final_second_user_energy_amount +=
-        20_000 * user_balance * (third_unlock_epoch - current_epoch) / 100_000u64;
-    final_second_user_energy_amount +=
-        40_000 * user_balance * (forth_unlock_epoch - current_epoch) / 100_000u64;
-
-    b_mock
-        .execute_query(&energy_factory, |sc| {
-            let expected_energy = Energy::new(
-                (managed_biguint!(final_second_user_energy_amount)).into(),
-                current_epoch,
-                managed_biguint!(user_balance),
-            );
-            let actual_energy = sc.user_energy(&managed_address!(&second_user)).get();
             assert_eq!(actual_energy, expected_energy);
         })
         .assert_ok();

--- a/locked-asset/locked-token-wrapper/wasm/src/lib.rs
+++ b/locked-asset/locked-token-wrapper/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           10
+// Endpoints:                            8
 // Async Callback:                       1
-// Total number of exported functions:  12
+// Total number of exported functions:  10
 
 #![no_std]
 #![feature(alloc_error_handler, lang_items)]
@@ -23,8 +23,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         issueWrappedToken
         setTransferRoleWrappedToken
         unsetTransferRoleWrappedToken
-        getLockedTokenId
-        getOldLockedTokenId
         getWrappedTokenId
         setEnergyFactoryAddress
         getEnergyFactoryAddress


### PR DESCRIPTION
- Remove the possibility to send wrapped LKMEX.
- Small code refactor, removing the storage for the locked tokens and just read them from the energy factory SC.