### PR TITLE
Fix merging locked tokens in case they have same unlock epoch

### DIFF
--- a/locked-asset/energy-factory/src/lock_options.rs
+++ b/locked-asset/energy-factory/src/lock_options.rs
@@ -44,6 +44,9 @@ pub trait LockOptionsModule {
 
     fn unlock_epoch_to_start_of_month_upper_estimate(&self, unlock_epoch: Epoch) -> Epoch {
         let lower_bound_unlock = self.unlock_epoch_to_start_of_month(unlock_epoch);
+        if unlock_epoch == lower_bound_unlock {
+          return lower_bound_unlock;
+        }
         let new_unlock_epoch = lower_bound_unlock + EPOCHS_PER_MONTH;
         let current_epoch = self.blockchain().get_block_epoch();
         if current_epoch >= new_unlock_epoch {

--- a/locked-asset/energy-factory/src/migration.rs
+++ b/locked-asset/energy-factory/src/migration.rs
@@ -162,13 +162,7 @@ pub trait SimpleLockMigrationModule:
             weight_sum += &epoch_amount_pair.amount;
         }
 
-        let base_lock_epochs_biguint_lower_estimate = weighted_epochs_sum.clone() / weight_sum.clone();
-        let base_lock_epochs_biguint =
-          if weighted_epochs_sum % weight_sum == 0 {
-            base_lock_epochs_biguint_lower_estimate
-          } else {
-            base_lock_epochs_biguint_lower_estimate + BigUint::from(1u32)
-          };
+        let base_lock_epochs_biguint = weighted_epochs_sum / weight_sum;
         let base_lock_epochs = base_lock_epochs_biguint
             .to_u64()
             .unwrap_or_panic::<Self::Api>();

--- a/locked-asset/energy-factory/src/migration.rs
+++ b/locked-asset/energy-factory/src/migration.rs
@@ -162,7 +162,13 @@ pub trait SimpleLockMigrationModule:
             weight_sum += &epoch_amount_pair.amount;
         }
 
-        let base_lock_epochs_biguint = weighted_epochs_sum / weight_sum;
+        let base_lock_epochs_biguint_lower_estimate = weighted_epochs_sum.clone() / weight_sum.clone();
+        let base_lock_epochs_biguint =
+          if weighted_epochs_sum % weight_sum == 0 {
+            base_lock_epochs_biguint_lower_estimate
+          } else {
+            base_lock_epochs_biguint_lower_estimate + BigUint::from(1u32)
+          };
         let base_lock_epochs = base_lock_epochs_biguint
             .to_u64()
             .unwrap_or_panic::<Self::Api>();

--- a/locked-asset/proxy_dex/tests/proxy_farm_test.rs
+++ b/locked-asset/proxy_dex/tests/proxy_farm_test.rs
@@ -208,7 +208,7 @@ fn farm_proxy_actions_test() {
         Some(&WrappedFarmTokenAttributes::<DebugApi> {
             proxy_farming_token: EsdtTokenPayment {
                 token_identifier: managed_token_id!(LOCKED_TOKEN_ID),
-                token_nonce: 3,
+                token_nonce: 1,
                 amount: managed_biguint!(USER_BALANCE),
             },
             farm_token: EsdtTokenPayment {

--- a/locked-asset/proxy_dex/tests/proxy_lp_test.rs
+++ b/locked-asset/proxy_dex/tests/proxy_lp_test.rs
@@ -494,7 +494,7 @@ fn tripple_add_liquidity_proxy_test() {
 }
 
 #[test]
-fn wrapped_lp_token_merge_test() {
+fn wrapped_lp_token_merge_same_unlock_epoch_test() {
     let mut setup = ProxySetup::new(
         proxy_dex::contract_obj,
         pair::contract_obj,
@@ -563,7 +563,7 @@ fn wrapped_lp_token_merge_test() {
         Some(&WrappedLpTokenAttributes::<DebugApi> {
             locked_tokens: EsdtTokenPayment {
                 token_identifier: managed_token_id!(LOCKED_TOKEN_ID),
-                token_nonce: 3,
+                token_nonce: 1,
                 amount: managed_biguint!(800_001_600), // out of 1_000_000_000
             },
             lp_token_id: managed_token_id!(LP_TOKEN_ID),


### PR DESCRIPTION
Fixing an issue reported by the community, where merging 2 XMEX unlocking in the same month (e.g. March 2026) would give an XMEX unlocking at the next month (e.g. April 2026).
Also, adapting the weighted average calculation for the unlock epoch of an XMEX obtained when converting an LKMEX, to make sure the result is not underestimated.