### PR TITLE
Claim on behalf legacy tokens check

### DIFF
--- a/common/modules/original_owner_helper/src/lib.rs
+++ b/common/modules/original_owner_helper/src/lib.rs
@@ -23,6 +23,11 @@ pub trait OriginalOwnerHelperModule {
             let attributes: T = farm_token_mapper.get_token_attributes(payment.token_nonce);
             let payment_original_owner = attributes.get_original_owner();
 
+            require!(
+                !payment_original_owner.is_zero(),
+                "Cannot claim rewards with legacy positions"
+            );
+
             match opt_original_owner {
                 Some(ref original_owner) => {
                     require!(

--- a/common/modules/original_owner_helper/src/lib.rs
+++ b/common/modules/original_owner_helper/src/lib.rs
@@ -25,7 +25,7 @@ pub trait OriginalOwnerHelperModule {
 
             require!(
                 !payment_original_owner.is_zero(),
-                "Cannot claim rewards with legacy positions"
+                "Cannot claim rewards on behalf of legacy positions"
             );
 
             match opt_original_owner {


### PR DESCRIPTION
Added a check to properly show to the users that they cannot use the claimOnBehalf endpoint using legacy tokens (that don't have the originalOwner value).