### PR TITLE
MEX Governance top farms functionality

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,7 +22,7 @@ jobs:
     name: Contracts
     uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v4.2.2
     with:
-      rust-toolchain: stable
+      rust-toolchain: 1.86
       coverage-args: --ignore-filename-regex='/.cargo/git' --output ./coverage.md
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: multiversx/mx-sc-actions/.github/workflows/reproducible-build.yml@v4.2.2
     with:
-      image_tag: v7.0.0
+      image_tag: v10.0.0
       attach_to_existing_release: true

--- a/energy-integration/mex-governance/src/config.rs
+++ b/energy-integration/mex-governance/src/config.rs
@@ -5,6 +5,12 @@ use week_timekeeping::Week;
 
 use crate::errors::{EMISSION_RATE_ZERO, INVALID_ESDT_IDENTIFIER};
 
+/// Constant for maximum number of farms that receive rewards
+pub const MAX_REWARDED_FARMS: usize = 25;
+
+/// Maximum number of farms a user can vote for in a single transaction
+pub const MAX_FARMS_PER_VOTE: usize = 10;
+
 #[derive(
     ManagedVecItem,
     TopEncode,
@@ -16,7 +22,6 @@ use crate::errors::{EMISSION_RATE_ZERO, INVALID_ESDT_IDENTIFIER};
     PartialEq,
     Debug,
 )]
-
 pub struct FarmEmission<M: ManagedTypeApi> {
     pub farm_address: ManagedAddress<M>,
     pub farm_emission: BigUint<M>,
@@ -115,6 +120,18 @@ pub trait ConfigModule:
         user_id: AddressId,
         week: Week,
     ) -> SingleValueMapper<ManagedVec<FarmVote<Self::Api>>>;
+
+    #[storage_mapper("farmEmissionsForWeek")]
+    fn farm_emissions_for_week(
+        &self,
+        week: Week,
+    ) -> SingleValueMapper<ManagedVec<FarmEmission<Self::Api>>>;
+
+    #[storage_mapper("redistributedVotesForWeek")]
+    fn redistributed_votes_for_week(&self, week: Week) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("topFarmsWhitelist")]
+    fn top_farms_whitelist(&self, week: Week) -> WhitelistMapper<ManagedAddress>;
 
     // General storages
 

--- a/energy-integration/mex-governance/src/external_interactions/farm_interactions.rs
+++ b/energy-integration/mex-governance/src/external_interactions/farm_interactions.rs
@@ -1,6 +1,6 @@
 multiversx_sc::imports!();
 
-use crate::{config::FarmEmission, errors::FARM_NOT_FOUND};
+use crate::config::FarmEmission;
 
 #[multiversx_sc::module]
 pub trait FarmInteractionsModule:
@@ -12,32 +12,98 @@ pub trait FarmInteractionsModule:
     #[endpoint(setFarmEmissions)]
     fn set_farm_emissions(&self) {
         let current_week = self.get_current_week();
-        let emission_rate = self.emission_rate_for_week(current_week).get();
+        let previous_week = current_week - 1; // Current week starts from 1, so we shouldn't overflow
+        if previous_week > 0 {
+            self.reset_previous_farms_emissions(previous_week);
+        }
+
+        let total_emission_rate = self.emission_rate_for_week(current_week).get();
         let total_votes = self.total_energy_voted(current_week).get();
 
-        let mut farm_emissions = ManagedVec::new();
+        if total_votes == 0 {
+            return;
+        }
 
-        for farm_id in self.voted_farms_for_week(current_week).iter() {
-            let farm_address_opt = self.farm_ids().get_address(farm_id);
-            require!(farm_address_opt.is_some(), FARM_NOT_FOUND);
+        let current_farm_emissions = self.farm_emissions_for_week(current_week).get();
 
-            let farm_address = unsafe { farm_address_opt.unwrap_unchecked() };
+        if current_farm_emissions.is_empty() {
+            return;
+        }
 
-            let farm_votes = self.farm_votes_for_week(farm_id, current_week).get();
+        self.distribute_emissions(
+            current_week,
+            current_farm_emissions,
+            total_emission_rate,
+            total_votes,
+        );
+    }
 
-            let farm_emission = &emission_rate * &farm_votes / &total_votes;
-            self.farm_proxy(farm_address.clone())
+    fn distribute_emissions(
+        &self,
+        week: usize,
+        farm_emissions: ManagedVec<FarmEmission<Self::Api>>,
+        total_emission_rate: BigUint,
+        total_votes: BigUint,
+    ) {
+        let redistributed_votes = self.redistributed_votes_for_week(week).get();
+        let top_farms_total_votes = &total_votes - &redistributed_votes;
+        let mut new_farm_emissions = ManagedVec::new();
+        let mut total_distributed = BigUint::zero();
+
+        let farms_to_process = farm_emissions.len() - 1;
+        for i in 0..farms_to_process {
+            let farm = farm_emissions.get(i);
+
+            let mut farm_emission = &total_emission_rate * &farm.farm_emission / &total_votes;
+            if redistributed_votes > 0 {
+                let redistributed_emission = &total_emission_rate
+                    * &(&redistributed_votes / &total_votes)
+                    * (&farm.farm_emission / &top_farms_total_votes);
+                farm_emission += redistributed_emission;
+            }
+
+            total_distributed += &farm_emission;
+
+            self.farm_proxy(farm.farm_address.clone())
                 .set_per_block_rewards_endpoint(farm_emission.clone())
                 .execute_on_dest_context::<()>();
 
-            farm_emissions.push(FarmEmission {
-                farm_address,
-                farm_emission,
+            new_farm_emissions.push(FarmEmission {
+                farm_address: farm.farm_address,
+                farm_emission: farm_emission.clone(),
             });
         }
 
-        // Add event emission
-        self.emit_farm_emissions_event(current_week, farm_emissions);
+        require!(
+            total_distributed <= total_emission_rate,
+            "Total distributed emissions exceed the total emission rate"
+        );
+
+        if farm_emissions.len() > 0 {
+            let last_farm = farm_emissions.get(farm_emissions.len() - 1);
+            let last_farm_emission = &total_emission_rate - &total_distributed;
+
+            self.farm_proxy(last_farm.farm_address.clone())
+                .set_per_block_rewards_endpoint(last_farm_emission.clone())
+                .execute_on_dest_context::<()>();
+
+            new_farm_emissions.push(FarmEmission {
+                farm_address: last_farm.farm_address,
+                farm_emission: last_farm_emission,
+            });
+        }
+
+        self.emit_farm_emissions_event(week, new_farm_emissions);
+    }
+
+    fn reset_previous_farms_emissions(&self, week: usize) {
+        let previous_farms = self.farm_emissions_for_week(week).get();
+
+        for farm_emission in previous_farms.iter() {
+            self.farm_proxy(farm_emission.farm_address.clone())
+                .end_produce_rewards_endpoint()
+                .execute_on_dest_context::<()>();
+        }
     }
 
     #[proxy]

--- a/energy-integration/mex-governance/src/external_interactions/farm_interactions.rs
+++ b/energy-integration/mex-governance/src/external_interactions/farm_interactions.rs
@@ -47,6 +47,11 @@ pub trait FarmInteractionsModule:
     ) {
         let redistributed_votes = self.redistributed_votes_for_week(week).get();
         let top_farms_total_votes = &total_votes - &redistributed_votes;
+
+        if top_farms_total_votes == 0 {
+            return;
+        }
+
         let mut new_farm_emissions = ManagedVec::new();
         let mut total_distributed = BigUint::zero();
 
@@ -55,11 +60,14 @@ pub trait FarmInteractionsModule:
             let farm = farm_emissions.get(i);
 
             let mut farm_emission = &total_emission_rate * &farm.farm_emission / &total_votes;
+
             if redistributed_votes > 0 {
-                let redistributed_emission = &total_emission_rate
-                    * &(&redistributed_votes / &total_votes)
-                    * (&farm.farm_emission / &top_farms_total_votes);
-                farm_emission += redistributed_emission;
+                let total_redistributed_emission =
+                    &total_emission_rate * &redistributed_votes / &total_votes;
+
+                let farm_redistribution_share =
+                    &total_redistributed_emission * &farm.farm_emission / &top_farms_total_votes;
+                farm_emission += farm_redistribution_share;
             }
 
             total_distributed += &farm_emission;

--- a/energy-integration/mex-governance/src/vote.rs
+++ b/energy-integration/mex-governance/src/vote.rs
@@ -1,7 +1,7 @@
 multiversx_sc::imports!();
 
 use crate::{
-    config::{FarmEmission, FarmVote},
+    config::{FarmEmission, FarmVote, MAX_FARMS_PER_VOTE, MAX_REWARDED_FARMS},
     errors::{ALREADY_VOTED_THIS_WEEK, FARM_BLACKLISTED, INVALID_VOTE_AMOUNT},
 };
 
@@ -15,6 +15,11 @@ pub trait VoteModule:
 {
     #[endpoint(vote)]
     fn vote(&self, votes: MultiValueEncoded<MultiValue2<ManagedAddress, BigUint>>) {
+        require!(
+            votes.len() <= MAX_FARMS_PER_VOTE,
+            "Too many farms in one vote"
+        );
+
         let caller = self.blockchain().get_caller();
         let user_id = self.user_ids().get_id_or_insert(&caller);
 
@@ -34,6 +39,7 @@ pub trait VoteModule:
         let mut total_vote_amount = BigUint::zero();
         let mut farm_votes = ManagedVec::new();
         let mut farm_votes_event = ManagedVec::new();
+
         for vote in votes {
             let (farm_address, amount) = vote.into_tuple();
 
@@ -66,7 +72,101 @@ pub trait VoteModule:
             .update(|sum| *sum += &user_energy);
         user_votes_in_week_mapper.set(&farm_votes);
 
+        self.update_top_farms(voting_week, &farm_votes_event);
+
         self.emit_vote_event(voting_week, farm_votes_event);
+    }
+
+    fn update_top_farms(&self, week: usize, new_votes: &ManagedVec<FarmEmission<Self::Api>>) {
+        let mut top_farms = self.farm_emissions_for_week(week).get();
+        let mut redistributed_votes = self.redistributed_votes_for_week(week).get();
+
+        self.add_new_votes(week, &mut top_farms, new_votes);
+        self.selection_sort_farms_desc(&mut top_farms);
+        self.trim_top_farms(week, &mut top_farms, &mut redistributed_votes);
+
+        self.farm_emissions_for_week(week).set(&top_farms);
+        self.redistributed_votes_for_week(week)
+            .set(&redistributed_votes);
+    }
+
+    fn add_new_votes(
+        &self,
+        week: usize,
+        top_farms: &mut ManagedVec<FarmEmission<Self::Api>>,
+        new_votes: &ManagedVec<FarmEmission<Self::Api>>,
+    ) {
+        for farm_vote in new_votes.iter() {
+            let farm_address = farm_vote.farm_address.clone();
+            let vote_amount = farm_vote.farm_emission.clone();
+
+            let is_in_top_farms = self.top_farms_whitelist(week).contains(&farm_address);
+
+            if is_in_top_farms {
+                for i in 0..top_farms.len() {
+                    if &top_farms.get(i).farm_address == &farm_address {
+                        let mut farm_emission = top_farms.get(i);
+                        farm_emission.farm_emission += vote_amount;
+                        let _ = top_farms.set(i, &farm_emission);
+                        break;
+                    }
+                }
+            } else {
+                // Add new farm to the list, even if it goes beyond max limit. Also, add to whitelist temporarily.
+                // This will help simplify the sorting logic later on
+                top_farms.push(FarmEmission {
+                    farm_address: farm_address.clone(),
+                    farm_emission: vote_amount,
+                });
+
+                self.top_farms_whitelist(week).add(&farm_address);
+            }
+        }
+    }
+
+    // Selection sort algorith
+    fn selection_sort_farms_desc(&self, farms: &mut ManagedVec<FarmEmission<Self::Api>>) {
+        let len = farms.len();
+
+        if len <= 1 {
+            return;
+        }
+
+        for i in 0..len - 1 {
+            let mut max_idx = i;
+            for j in i + 1..len {
+                if farms.get(j).farm_emission > farms.get(max_idx).farm_emission {
+                    max_idx = j;
+                }
+            }
+
+            if max_idx != i {
+                let max_farm = farms.get(max_idx);
+                let current_farm = farms.get(i);
+
+                let _ = farms.set(i, &max_farm);
+                let _ = farms.set(max_idx, &current_farm);
+            }
+        }
+    }
+
+    fn trim_top_farms(
+        &self,
+        week: usize,
+        top_farms: &mut ManagedVec<FarmEmission<Self::Api>>,
+        redistributed_votes: &mut BigUint,
+    ) {
+        if top_farms.len() > MAX_REWARDED_FARMS {
+            for i in MAX_REWARDED_FARMS..top_farms.len() {
+                *redistributed_votes += &top_farms.get(i).farm_emission;
+
+                self.top_farms_whitelist(week)
+                    .remove(&top_farms.get(i).farm_address);
+            }
+
+            let top_farms_slice = top_farms.slice(0, MAX_REWARDED_FARMS).unwrap_or_default();
+            *top_farms = top_farms_slice;
+        }
     }
 
     fn advance_week_if_needed(&self, voting_week: usize) {
@@ -76,6 +176,11 @@ pub trait VoteModule:
 
             let emission_rate = self.reference_emission_rate().get();
             self.emission_rate_for_week(voting_week).set(emission_rate);
+
+            self.farm_emissions_for_week(voting_week)
+                .set(ManagedVec::new());
+            self.redistributed_votes_for_week(voting_week)
+                .set(BigUint::zero());
         }
     }
 }

--- a/energy-integration/mex-governance/src/vote.rs
+++ b/energy-integration/mex-governance/src/vote.rs
@@ -103,14 +103,7 @@ pub trait VoteModule:
             let is_in_top_farms = self.top_farms_whitelist(week).contains(&farm_address);
 
             if is_in_top_farms {
-                for i in 0..top_farms.len() {
-                    if &top_farms.get(i).farm_address == &farm_address {
-                        let mut farm_emission = top_farms.get(i);
-                        farm_emission.farm_emission += vote_amount;
-                        let _ = top_farms.set(i, &farm_emission);
-                        break;
-                    }
-                }
+                self.update_existing_farm_emission(top_farms, &farm_address, &vote_amount);
             } else {
                 // Add new farm to the list, even if it goes beyond max limit. Also, add to whitelist temporarily.
                 // This will help simplify the sorting logic later on
@@ -120,6 +113,22 @@ pub trait VoteModule:
                 });
 
                 self.top_farms_whitelist(week).add(&farm_address);
+            }
+        }
+    }
+
+    fn update_existing_farm_emission(
+        &self,
+        top_farms: &mut ManagedVec<FarmEmission<Self::Api>>,
+        farm_address: &ManagedAddress,
+        vote_amount: &BigUint,
+    ) {
+        for i in 0..top_farms.len() {
+            if &top_farms.get(i).farm_address == farm_address {
+                let mut farm_emission = top_farms.get(i);
+                farm_emission.farm_emission += vote_amount;
+                let _ = top_farms.set(i, &farm_emission);
+                break;
             }
         }
     }

--- a/energy-integration/mex-governance/tests/mex_governance_setup/mod.rs
+++ b/energy-integration/mex-governance/tests/mex_governance_setup/mod.rs
@@ -1,7 +1,9 @@
 #![allow(deprecated)]
 
 use config::ConfigModule;
-use energy_factory::{energy::EnergyModule, SimpleLockEnergy};
+use energy_factory::{
+    energy::EnergyModule, unlocked_token_transfer::UnlockedTokenTransferModule, SimpleLockEnergy,
+};
 use energy_query::{Energy, EnergyQueryModule};
 use farm_boosted_yields::boosted_yields_factors::BoostedYieldsFactorsModule;
 use farm_token::FarmTokenModule;
@@ -376,6 +378,17 @@ where
             })
             .assert_ok();
 
+        // Whitelist farms in energy factory
+        b_mock
+            .execute_tx(&owner, &energy_factory_wrapper, &rust_zero, |sc| {
+                let mut farms = MultiValueEncoded::new();
+                farms.push(managed_address!(farm_wm_wrapper.address_ref()));
+                farms.push(managed_address!(farm_wu_wrapper.address_ref()));
+                farms.push(managed_address!(farm_wh_wrapper.address_ref()));
+                sc.add_to_unlocked_token_mint_whitelist(farms);
+            })
+            .assert_ok();
+
         // init governance sc
         b_mock
             .execute_tx(&owner, &gov_wrapper, &rust_zero, |sc| {
@@ -384,12 +397,6 @@ where
                     managed_token_id!(MEX_TOKEN_ID),
                     managed_address!(energy_factory_wrapper.address_ref()),
                 );
-
-                let mut farms = MultiValueEncoded::new();
-                farms.push(managed_address!(farm_wm_wrapper.address_ref()));
-                farms.push(managed_address!(farm_wu_wrapper.address_ref()));
-                farms.push(managed_address!(farm_wh_wrapper.address_ref()));
-                sc.whitelist_farms(farms);
             })
             .assert_ok();
 

--- a/energy-integration/mex-governance/tests/mex_governance_setup/mod.rs
+++ b/energy-integration/mex-governance/tests/mex_governance_setup/mod.rs
@@ -10,11 +10,12 @@ use farm_token::FarmTokenModule;
 use farm_with_locked_rewards::Farm;
 
 use mex_governance::{
-    config::ConfigModule as _, incentive::IncentiveModule, vote::VoteModule, MEXGovernance,
+    config::ConfigModule as _, external_interactions::farm_interactions::FarmInteractionsModule,
+    incentive::IncentiveModule, vote::VoteModule, MEXGovernance,
 };
 use multiversx_sc::{
     imports::{MultiValue2, MultiValue3, StorageTokenWrapper},
-    types::{Address, BigInt, ManagedAddress, MultiValueEncoded},
+    types::{Address, BigInt, MultiValueEncoded},
 };
 use multiversx_sc_scenario::{
     imports::TxResult,
@@ -24,23 +25,15 @@ use multiversx_sc_scenario::{
 };
 
 use locking_module::lock_with_energy_module::LockWithEnergyModule;
-use pair::{config::ConfigModule as _, Pair};
 use pausable::{PausableModule, State};
 use permissions_module::PermissionsModule as _;
 use simple_lock::locked_token::LockedTokenModule;
 
-pub const WEGLD_TOKEN_ID: &[u8] = b"WEGLD-123456";
 pub const MEX_TOKEN_ID: &[u8] = b"MEX-123456";
-pub const USDC_TOKEN_ID: &[u8] = b"USDC-123456";
-pub const HTM_TOKEN_ID: &[u8] = b"HTM-123456";
 pub static LOCKED_TOKEN_ID: &[u8] = b"LOCKED-123456";
 pub static LEGACY_LOCKED_TOKEN_ID: &[u8] = b"LEGACY-123456";
-pub static WEGLDMEX_FARMING_TOKEN_ID: &[u8] = b"WMLPTOK-123456";
-pub static WEGLDUSDC_FARMING_TOKEN_ID: &[u8] = b"WULPTOK-123456";
-pub static WEGLDHTM_FARMING_TOKEN_ID: &[u8] = b"WHLPTOK-123456";
-pub static WEGLDMEXFARM_TOKEN_ID: &[u8] = b"WMFARM-123456";
-pub static WEGLDUSDCFARM_TOKEN_ID: &[u8] = b"WUFARM-123456";
-pub static WEGLDHTMFARM_TOKEN_ID: &[u8] = b"WHFARM-123456";
+pub static FARMING_TOKEN_ID: &[u8] = b"LPTOK-123456";
+pub static FARM_TOKEN_ID: &[u8] = b"FARMTOK-123456";
 
 pub const MAX_REWARDS_FACTOR: u64 = 10;
 pub const USER_REWARDS_ENERGY_CONST: u64 = 3;
@@ -56,9 +49,8 @@ pub const PER_BLOCK_REWARD_AMOUNT: u64 = 1_000;
 pub static LOCK_OPTIONS: &[u64] = &[EPOCHS_IN_YEAR, 2 * EPOCHS_IN_YEAR, 4 * EPOCHS_IN_YEAR];
 pub static PENALTY_PERCENTAGES: &[u64] = &[4_000, 6_000, 8_000];
 
-pub struct GovSetup<PairBuilder, FarmLockedBuilder, EnergyFactoryBuilder, GovBuilder>
+pub struct GovSetup<FarmLockedBuilder, EnergyFactoryBuilder, GovBuilder>
 where
-    PairBuilder: 'static + Copy + Fn() -> pair::ContractObj<DebugApi>,
     FarmLockedBuilder: 'static + Copy + Fn() -> farm_with_locked_rewards::ContractObj<DebugApi>,
     EnergyFactoryBuilder: 'static + Copy + Fn() -> energy_factory::ContractObj<DebugApi>,
     GovBuilder: 'static + Copy + Fn() -> mex_governance::ContractObj<DebugApi>,
@@ -68,33 +60,35 @@ where
     pub first_user: Address,
     pub second_user: Address,
     pub third_user: Address,
-    pub pair_wm_wrapper: ContractObjWrapper<pair::ContractObj<DebugApi>, PairBuilder>,
-    pub pair_wu_wrapper: ContractObjWrapper<pair::ContractObj<DebugApi>, PairBuilder>,
-    pub pair_wh_wrapper: ContractObjWrapper<pair::ContractObj<DebugApi>, PairBuilder>,
-    pub farm_wm_wrapper:
-        ContractObjWrapper<farm_with_locked_rewards::ContractObj<DebugApi>, FarmLockedBuilder>,
-    pub farm_wu_wrapper:
-        ContractObjWrapper<farm_with_locked_rewards::ContractObj<DebugApi>, FarmLockedBuilder>,
-    pub farm_wh_wrapper:
-        ContractObjWrapper<farm_with_locked_rewards::ContractObj<DebugApi>, FarmLockedBuilder>,
+    pub farms: Vec<Address>,
+    pub farm_wrappers:
+        Vec<ContractObjWrapper<farm_with_locked_rewards::ContractObj<DebugApi>, FarmLockedBuilder>>,
     pub energy_factory_wrapper:
         ContractObjWrapper<energy_factory::ContractObj<DebugApi>, EnergyFactoryBuilder>,
     pub gov_wrapper: ContractObjWrapper<mex_governance::ContractObj<DebugApi>, GovBuilder>,
+    pub dummy_pair_address: Address,
 }
 
-impl<PairBuilder, FarmLockedBuilder, EnergyFactoryBuilder, GovBuilder>
-    GovSetup<PairBuilder, FarmLockedBuilder, EnergyFactoryBuilder, GovBuilder>
+impl<FarmLockedBuilder, EnergyFactoryBuilder, GovBuilder>
+    GovSetup<FarmLockedBuilder, EnergyFactoryBuilder, GovBuilder>
 where
-    PairBuilder: 'static + Copy + Fn() -> pair::ContractObj<DebugApi>,
     FarmLockedBuilder: 'static + Copy + Fn() -> farm_with_locked_rewards::ContractObj<DebugApi>,
     EnergyFactoryBuilder: 'static + Copy + Fn() -> energy_factory::ContractObj<DebugApi>,
     GovBuilder: 'static + Copy + Fn() -> mex_governance::ContractObj<DebugApi>,
 {
     pub fn new(
-        pair_builder: PairBuilder,
         farm_builder: FarmLockedBuilder,
         energy_factory_builder: EnergyFactoryBuilder,
         gov_builder: GovBuilder,
+    ) -> Self {
+        Self::new_with_farms(farm_builder, energy_factory_builder, gov_builder, 3)
+    }
+
+    pub fn new_with_farms(
+        farm_builder: FarmLockedBuilder,
+        energy_factory_builder: EnergyFactoryBuilder,
+        gov_builder: GovBuilder,
+        initial_farm_count: usize,
     ) -> Self {
         let rust_zero = rust_biguint!(0);
         let mut b_mock = BlockchainStateWrapper::new();
@@ -102,6 +96,9 @@ where
         let first_user = b_mock.create_user_account(&rust_zero);
         let second_user = b_mock.create_user_account(&rust_zero);
         let third_user = b_mock.create_user_account(&rust_zero);
+
+        // Create dummy pair address
+        let dummy_pair_address = b_mock.create_user_account(&rust_zero);
 
         // init energy factory
         let energy_factory_wrapper = b_mock.create_sc_account(
@@ -131,265 +128,10 @@ where
             })
             .assert_ok();
 
-        // init pairs
-        // WEGLD-MEX pair
-        let pair_wm_wrapper =
-            b_mock.create_sc_account(&rust_biguint!(0), Some(&owner), pair_builder, "pair path");
-
-        b_mock
-            .execute_tx(&owner, &pair_wm_wrapper, &rust_zero, |sc| {
-                let first_token_id = managed_token_id!(WEGLD_TOKEN_ID);
-                let second_token_id = managed_token_id!(MEX_TOKEN_ID);
-                let router_address = managed_address!(&owner);
-                let router_owner_address = managed_address!(&owner);
-                let total_fee_percent = 300u64;
-                let special_fee_percent = 50u64;
-
-                sc.init(
-                    first_token_id,
-                    second_token_id,
-                    router_address,
-                    router_owner_address,
-                    total_fee_percent,
-                    special_fee_percent,
-                    ManagedAddress::<DebugApi>::zero(),
-                    MultiValueEncoded::<DebugApi, ManagedAddress<DebugApi>>::new(),
-                );
-
-                let lp_token_id = managed_token_id!(WEGLDMEX_FARMING_TOKEN_ID);
-                sc.lp_token_identifier().set(&lp_token_id);
-
-                sc.state().set(State::Active);
-            })
-            .assert_ok();
-
-        // WEGLD-USDC pair
-        let pair_wu_wrapper =
-            b_mock.create_sc_account(&rust_biguint!(0), Some(&owner), pair_builder, "pair path");
-
-        b_mock
-            .execute_tx(&owner, &pair_wu_wrapper, &rust_zero, |sc| {
-                let first_token_id = managed_token_id!(WEGLD_TOKEN_ID);
-                let second_token_id = managed_token_id!(USDC_TOKEN_ID);
-                let router_address = managed_address!(&owner);
-                let router_owner_address = managed_address!(&owner);
-                let total_fee_percent = 300u64;
-                let special_fee_percent = 50u64;
-
-                sc.init(
-                    first_token_id,
-                    second_token_id,
-                    router_address,
-                    router_owner_address,
-                    total_fee_percent,
-                    special_fee_percent,
-                    ManagedAddress::<DebugApi>::zero(),
-                    MultiValueEncoded::<DebugApi, ManagedAddress<DebugApi>>::new(),
-                );
-
-                let lp_token_id = managed_token_id!(WEGLDUSDC_FARMING_TOKEN_ID);
-                sc.lp_token_identifier().set(&lp_token_id);
-
-                sc.state().set(State::Active);
-            })
-            .assert_ok();
-
-        // WEGLD-HTM pair
-        let pair_wh_wrapper =
-            b_mock.create_sc_account(&rust_biguint!(0), Some(&owner), pair_builder, "pair path");
-
-        b_mock
-            .execute_tx(&owner, &pair_wh_wrapper, &rust_zero, |sc| {
-                let first_token_id = managed_token_id!(WEGLD_TOKEN_ID);
-                let second_token_id = managed_token_id!(HTM_TOKEN_ID);
-                let router_address = managed_address!(&owner);
-                let router_owner_address = managed_address!(&owner);
-                let total_fee_percent = 300u64;
-                let special_fee_percent = 50u64;
-
-                sc.init(
-                    first_token_id,
-                    second_token_id,
-                    router_address,
-                    router_owner_address,
-                    total_fee_percent,
-                    special_fee_percent,
-                    ManagedAddress::<DebugApi>::zero(),
-                    MultiValueEncoded::<DebugApi, ManagedAddress<DebugApi>>::new(),
-                );
-
-                let lp_token_id = managed_token_id!(WEGLDHTM_FARMING_TOKEN_ID);
-                sc.lp_token_identifier().set(&lp_token_id);
-
-                sc.state().set(State::Active);
-            })
-            .assert_ok();
-
-        // Init farm with locked rewards
-
-        // Declare the governance SC
+        // init governance sc
         let gov_wrapper =
             b_mock.create_sc_account(&rust_zero, Some(&owner), gov_builder, "gov path");
 
-        // WEGLD-MEX farm
-        let farm_wm_wrapper = b_mock.create_sc_account(
-            &rust_zero,
-            Some(&owner),
-            farm_builder,
-            "farm-with-locked-rewards.wasm",
-        );
-
-        b_mock
-            .execute_tx(&owner, &farm_wm_wrapper, &rust_zero, |sc| {
-                let reward_token_id = managed_token_id!(MEX_TOKEN_ID);
-                let farming_token_id = managed_token_id!(WEGLDMEX_FARMING_TOKEN_ID);
-                let division_safety_constant = managed_biguint!(DIV_SAFETY);
-                let pair_address = managed_address!(&pair_wm_wrapper.address_ref());
-
-                sc.init(
-                    reward_token_id,
-                    farming_token_id,
-                    division_safety_constant,
-                    pair_address,
-                    managed_address!(&owner),
-                    MultiValueEncoded::new(),
-                );
-
-                let farm_token_id = managed_token_id!(WEGLDMEXFARM_TOKEN_ID);
-                sc.farm_token().set_token_id(farm_token_id);
-
-                sc.per_block_reward_amount()
-                    .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
-
-                sc.state().set(State::Active);
-                sc.produce_rewards_enabled().set(true);
-
-                sc.set_boosted_yields_factors(
-                    managed_biguint!(MAX_REWARDS_FACTOR),
-                    managed_biguint!(USER_REWARDS_ENERGY_CONST),
-                    managed_biguint!(USER_REWARDS_FARM_CONST),
-                    managed_biguint!(MIN_ENERGY_AMOUNT_FOR_BOOSTED_YIELDS),
-                    managed_biguint!(MIN_FARM_AMOUNT_FOR_BOOSTED_YIELDS),
-                );
-                sc.set_locking_sc_address(managed_address!(energy_factory_wrapper.address_ref()));
-                sc.set_lock_epochs(EPOCHS_IN_YEAR);
-                sc.energy_factory_address()
-                    .set(managed_address!(energy_factory_wrapper.address_ref()));
-
-                sc.add_admin_endpoint(managed_address!(gov_wrapper.address_ref()));
-            })
-            .assert_ok();
-
-        // WEGLD-USDC farm
-        let farm_wu_wrapper = b_mock.create_sc_account(
-            &rust_zero,
-            Some(&owner),
-            farm_builder,
-            "farm-with-locked-rewards.wasm",
-        );
-
-        b_mock
-            .execute_tx(&owner, &farm_wu_wrapper, &rust_zero, |sc| {
-                let reward_token_id = managed_token_id!(MEX_TOKEN_ID);
-                let farming_token_id = managed_token_id!(WEGLDUSDC_FARMING_TOKEN_ID);
-                let division_safety_constant = managed_biguint!(DIV_SAFETY);
-                let pair_address = managed_address!(&pair_wu_wrapper.address_ref());
-
-                sc.init(
-                    reward_token_id,
-                    farming_token_id,
-                    division_safety_constant,
-                    pair_address,
-                    managed_address!(&owner),
-                    MultiValueEncoded::new(),
-                );
-
-                let farm_token_id = managed_token_id!(WEGLDUSDCFARM_TOKEN_ID);
-                sc.farm_token().set_token_id(farm_token_id);
-
-                sc.per_block_reward_amount()
-                    .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
-
-                sc.state().set(State::Active);
-                sc.produce_rewards_enabled().set(true);
-
-                sc.set_boosted_yields_factors(
-                    managed_biguint!(MAX_REWARDS_FACTOR),
-                    managed_biguint!(USER_REWARDS_ENERGY_CONST),
-                    managed_biguint!(USER_REWARDS_FARM_CONST),
-                    managed_biguint!(MIN_ENERGY_AMOUNT_FOR_BOOSTED_YIELDS),
-                    managed_biguint!(MIN_FARM_AMOUNT_FOR_BOOSTED_YIELDS),
-                );
-                sc.set_locking_sc_address(managed_address!(energy_factory_wrapper.address_ref()));
-                sc.set_lock_epochs(EPOCHS_IN_YEAR);
-                sc.energy_factory_address()
-                    .set(managed_address!(energy_factory_wrapper.address_ref()));
-
-                sc.add_admin_endpoint(managed_address!(gov_wrapper.address_ref()));
-            })
-            .assert_ok();
-
-        // WEGLD-HTM farm
-        let farm_wh_wrapper = b_mock.create_sc_account(
-            &rust_zero,
-            Some(&owner),
-            farm_builder,
-            "farm-with-locked-rewards.wasm",
-        );
-
-        b_mock
-            .execute_tx(&owner, &farm_wh_wrapper, &rust_zero, |sc| {
-                let reward_token_id = managed_token_id!(MEX_TOKEN_ID);
-                let farming_token_id = managed_token_id!(WEGLDHTM_FARMING_TOKEN_ID);
-                let division_safety_constant = managed_biguint!(DIV_SAFETY);
-                let pair_address = managed_address!(&pair_wh_wrapper.address_ref());
-
-                sc.init(
-                    reward_token_id,
-                    farming_token_id,
-                    division_safety_constant,
-                    pair_address,
-                    managed_address!(&owner),
-                    MultiValueEncoded::new(),
-                );
-
-                let farm_token_id = managed_token_id!(WEGLDHTMFARM_TOKEN_ID);
-                sc.farm_token().set_token_id(farm_token_id);
-
-                sc.per_block_reward_amount()
-                    .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
-
-                sc.state().set(State::Active);
-                sc.produce_rewards_enabled().set(true);
-
-                sc.set_boosted_yields_factors(
-                    managed_biguint!(MAX_REWARDS_FACTOR),
-                    managed_biguint!(USER_REWARDS_ENERGY_CONST),
-                    managed_biguint!(USER_REWARDS_FARM_CONST),
-                    managed_biguint!(MIN_ENERGY_AMOUNT_FOR_BOOSTED_YIELDS),
-                    managed_biguint!(MIN_FARM_AMOUNT_FOR_BOOSTED_YIELDS),
-                );
-                sc.set_locking_sc_address(managed_address!(energy_factory_wrapper.address_ref()));
-                sc.set_lock_epochs(EPOCHS_IN_YEAR);
-                sc.energy_factory_address()
-                    .set(managed_address!(energy_factory_wrapper.address_ref()));
-
-                sc.add_admin_endpoint(managed_address!(gov_wrapper.address_ref()));
-            })
-            .assert_ok();
-
-        // Whitelist farms in energy factory
-        b_mock
-            .execute_tx(&owner, &energy_factory_wrapper, &rust_zero, |sc| {
-                let mut farms = MultiValueEncoded::new();
-                farms.push(managed_address!(farm_wm_wrapper.address_ref()));
-                farms.push(managed_address!(farm_wu_wrapper.address_ref()));
-                farms.push(managed_address!(farm_wh_wrapper.address_ref()));
-                sc.add_to_unlocked_token_mint_whitelist(farms);
-            })
-            .assert_ok();
-
-        // init governance sc
         b_mock
             .execute_tx(&owner, &gov_wrapper, &rust_zero, |sc| {
                 sc.init(
@@ -400,23 +142,119 @@ where
             })
             .assert_ok();
 
-        Self {
+        let mut setup = Self {
             b_mock,
             owner,
             first_user,
             second_user,
             third_user,
-            pair_wm_wrapper,
-            pair_wu_wrapper,
-            pair_wh_wrapper,
-            farm_wm_wrapper,
-            farm_wu_wrapper,
-            farm_wh_wrapper,
+            farms: Vec::new(),
+            farm_wrappers: Vec::new(),
             energy_factory_wrapper,
             gov_wrapper,
+            dummy_pair_address,
+        };
+
+        // Deploy initial farms
+        if initial_farm_count > 0 {
+            setup.deploy_and_whitelist_farms(farm_builder, initial_farm_count);
+        }
+
+        setup
+    }
+
+    pub fn deploy_and_whitelist_farms(&mut self, farm_builder: FarmLockedBuilder, count: usize) {
+        let mut new_farm_addresses = Vec::new();
+
+        for _i in 0..count {
+            // Deploy farm
+            let farm_wrapper = self.b_mock.create_sc_account(
+                &rust_biguint!(0),
+                Some(&self.owner),
+                farm_builder,
+                "farm path",
+            );
+
+            let farm_address = farm_wrapper.address_ref().clone();
+            new_farm_addresses.push(farm_address.clone());
+
+            // Initialize farm
+            self.b_mock
+                .execute_tx(&self.owner, &farm_wrapper, &rust_biguint!(0), |sc| {
+                    let reward_token_id = managed_token_id!(MEX_TOKEN_ID);
+                    let farming_token_id = managed_token_id!(FARMING_TOKEN_ID);
+                    let division_safety_constant = managed_biguint!(DIV_SAFETY);
+                    let pair_address = managed_address!(&self.dummy_pair_address);
+
+                    sc.init(
+                        reward_token_id,
+                        farming_token_id,
+                        division_safety_constant,
+                        pair_address,
+                        managed_address!(&self.owner),
+                        MultiValueEncoded::new(),
+                    );
+
+                    let farm_token = managed_token_id!(FARM_TOKEN_ID);
+                    sc.farm_token().set_token_id(farm_token);
+
+                    sc.per_block_reward_amount()
+                        .set(&managed_biguint!(PER_BLOCK_REWARD_AMOUNT));
+
+                    sc.state().set(State::Active);
+                    sc.produce_rewards_enabled().set(true);
+
+                    sc.set_boosted_yields_factors(
+                        managed_biguint!(MAX_REWARDS_FACTOR),
+                        managed_biguint!(USER_REWARDS_ENERGY_CONST),
+                        managed_biguint!(USER_REWARDS_FARM_CONST),
+                        managed_biguint!(MIN_ENERGY_AMOUNT_FOR_BOOSTED_YIELDS),
+                        managed_biguint!(MIN_FARM_AMOUNT_FOR_BOOSTED_YIELDS),
+                    );
+                    sc.set_locking_sc_address(managed_address!(self
+                        .energy_factory_wrapper
+                        .address_ref()));
+                    sc.set_lock_epochs(EPOCHS_IN_YEAR);
+                    sc.energy_factory_address()
+                        .set(managed_address!(self.energy_factory_wrapper.address_ref()));
+
+                    sc.add_admin_endpoint(managed_address!(self.gov_wrapper.address_ref()));
+                })
+                .assert_ok();
+
+            // Store farm info
+            self.farms.push(farm_address);
+            self.farm_wrappers.push(farm_wrapper);
+        }
+
+        // Whitelist all new farms in energy factory
+        if !new_farm_addresses.is_empty() {
+            self.b_mock
+                .execute_tx(
+                    &self.owner,
+                    &self.energy_factory_wrapper,
+                    &rust_biguint!(0),
+                    |sc| {
+                        let mut farms = MultiValueEncoded::new();
+                        for farm_addr in &new_farm_addresses {
+                            farms.push(managed_address!(farm_addr));
+                        }
+                        sc.add_to_unlocked_token_mint_whitelist(farms);
+                    },
+                )
+                .assert_ok();
         }
     }
 
+    // Helper methods for backward compatibility
+    pub fn get_farm_address(&self, index: usize) -> Address {
+        self.farms
+            .get(index)
+            .expect("Farm index out of bounds")
+            .clone()
+    }
+
+    // Keep existing methods for compatibility
     pub fn vote(&mut self, user: Address, votes: Vec<MultiValue2<Address, u64>>) -> TxResult {
         self.b_mock
             .execute_tx(&user, &self.gov_wrapper, &rust_biguint!(0), |sc| {
@@ -492,6 +330,13 @@ where
                 let mut farms = MultiValueEncoded::new();
                 farms.push(managed_address!(&farm_address));
                 sc.blacklist_farm(farms);
+            })
+    }
+
+    pub fn set_farm_emissions(&mut self) -> TxResult {
+        self.b_mock
+            .execute_tx(&self.owner, &self.gov_wrapper, &rust_biguint!(0), |sc| {
+                sc.set_farm_emissions();
             })
     }
 }

--- a/energy-integration/mex-governance/tests/mex_governance_test.rs
+++ b/energy-integration/mex-governance/tests/mex_governance_test.rs
@@ -4,7 +4,7 @@ mod mex_governance_setup;
 
 use config::ConfigModule;
 use mex_governance::{
-    config::ConfigModule as _, external_interactions::ExternalInteractionsModule,
+    config::ConfigModule as _, external_interactions::farm_interactions::FarmInteractionsModule,
 };
 use mex_governance_setup::*;
 use multiversx_sc::imports::MultiValue2;
@@ -440,8 +440,6 @@ fn test_blacklist_farm_with_active_votes() {
 
             // Check farm is blacklisted
             assert!(sc.blacklisted_farms().contains(&farm_id));
-            // Check farm is not in whitelist
-            assert!(!sc.whitelisted_farms().contains(&farm_id));
         })
         .assert_ok();
 

--- a/energy-integration/mex-governance/tests/mex_governance_test.rs
+++ b/energy-integration/mex-governance/tests/mex_governance_test.rs
@@ -3,9 +3,7 @@
 mod mex_governance_setup;
 
 use config::ConfigModule;
-use mex_governance::{
-    config::ConfigModule as _, external_interactions::farm_interactions::FarmInteractionsModule,
-};
+use mex_governance::config::ConfigModule as _;
 use mex_governance_setup::*;
 use multiversx_sc::imports::MultiValue2;
 use multiversx_sc_scenario::{managed_address, managed_biguint, rust_biguint};
@@ -14,7 +12,6 @@ use week_timekeeping::WeekTimekeepingModule;
 #[test]
 fn init_gov_test() {
     let _ = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
@@ -23,22 +20,20 @@ fn init_gov_test() {
 
 #[test]
 fn test_whitelist_and_vote_single_farm() {
-    // setup
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
     );
 
     let first_user = gov_setup.first_user.clone();
-    let farm_wm = gov_setup.farm_wm_wrapper.address_ref().clone();
+    let farm_0 = gov_setup.get_farm_address(0);
 
     // Set user energy (needed for voting)
     gov_setup.set_user_energy(first_user.clone(), 1_000, 1, 1);
 
     // Vote for farm
-    let votes = vec![MultiValue2::from((farm_wm.clone(), 1_000u64))];
+    let votes = vec![MultiValue2::from((farm_0.clone(), 1_000u64))];
     gov_setup.vote(first_user.clone(), votes).assert_ok();
 
     // Verify vote was recorded correctly
@@ -48,7 +43,7 @@ fn test_whitelist_and_vote_single_farm() {
             let current_week = sc.get_current_week();
 
             // Check farm is in voted farms list
-            let farm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wm));
+            let farm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_0));
             assert!(sc.voted_farms_for_week(current_week + 1).contains(&farm_id));
 
             // Check vote amount
@@ -63,19 +58,139 @@ fn test_whitelist_and_vote_single_farm() {
 }
 
 #[test]
+fn test_rounding_errors_accumulation() {
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        25,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    let second_user = gov_setup.second_user.clone();
+    let third_user = gov_setup.third_user.clone();
+
+    // Use a prime number for total votes to ensure rounding errors
+    let user1_energy = 33_334u64;
+    let user2_energy = 33_335u64;
+    let user3_energy = 33_334u64;
+    let total_energy = user1_energy + user2_energy + user3_energy; // 100,003 - Prime number
+
+    gov_setup.set_user_energy(first_user.clone(), user1_energy, 1, user1_energy);
+    gov_setup.set_user_energy(second_user.clone(), user2_energy, 1, user2_energy);
+    gov_setup.set_user_energy(third_user.clone(), user3_energy, 1, user3_energy);
+
+    // Create an uneven distribution that will cause rounding errors
+
+    // First user votes
+    let mut votes = vec![];
+    votes.push(MultiValue2::from((gov_setup.get_farm_address(0), 7_919u64)));
+    for i in 1..8 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 3_500u64)));
+    }
+    votes.push(MultiValue2::from((gov_setup.get_farm_address(24), 915u64)));
+    // Total: 7919 + (7 * 3500) + 915 = 33,334
+    gov_setup.vote(first_user.clone(), votes).assert_ok();
+
+    // Second user votes
+    let mut votes = vec![];
+    for i in 8..17 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 3_703u64)));
+    }
+    votes.push(MultiValue2::from((gov_setup.get_farm_address(24), 8u64)));
+    // Total: (9 * 3703) + 8 = 33,335
+    gov_setup.vote(second_user.clone(), votes).assert_ok();
+
+    // Third user votes
+    let mut votes = vec![];
+    for i in 16..24 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 3_750u64)));
+    }
+    votes.push(MultiValue2::from((
+        gov_setup.get_farm_address(24),
+        1_334u64,
+    )));
+    votes.push(MultiValue2::from((gov_setup.get_farm_address(0), 2_000u64)));
+    // Total: (8 * 3750) + 1334 + 2000 = 33,334
+    gov_setup.vote(third_user.clone(), votes).assert_ok();
+
+    // Set emissions
+    gov_setup.b_mock.set_block_epoch(10);
+    gov_setup.set_farm_emissions().assert_ok();
+
+    // Calculate total distributed vs emission rate
+    let mut total_distributed = 0u64;
+    let emission_rate = DEFAULT_EMISSION_RATE; // 10,000
+
+    // Check all farms except the last one
+    for i in 0..24 {
+        let farm_wrapper = &gov_setup.farm_wrappers[i];
+        gov_setup
+            .b_mock
+            .execute_query(farm_wrapper, |sc| {
+                let per_block_rewards = sc.per_block_reward_amount().get();
+                total_distributed += per_block_rewards.to_u64().unwrap();
+            })
+            .assert_ok();
+    }
+
+    // Test that rounding errors accumulate to the last farm
+    let last_farm_wrapper = &gov_setup.farm_wrappers[24];
+    gov_setup
+        .b_mock
+        .execute_query(last_farm_wrapper, |sc| {
+            let per_block_rewards = sc.per_block_reward_amount().get();
+            let last_farm_emission = per_block_rewards.to_u64().unwrap();
+
+            // The last farm should get the remainder
+            let expected_last_farm = emission_rate - total_distributed;
+            assert_eq!(last_farm_emission, expected_last_farm);
+
+            // Total should equal emission rate exactly
+            assert_eq!(total_distributed + last_farm_emission, emission_rate);
+
+            // The last farm gets rounding errors, which could be positive or negative
+            // Calculate what it should have gotten without rounding adjustment
+            let last_farm_votes = 2_257u64; // 915 + 8 + 1334
+            let expected_without_rounding = (emission_rate * last_farm_votes) / total_energy;
+
+            // Assert that rounding error exists and is reasonable
+            let rounding_error = if last_farm_emission > expected_without_rounding {
+                last_farm_emission - expected_without_rounding
+            } else {
+                expected_without_rounding - last_farm_emission
+            };
+
+            // Rounding error should exist (non-zero) due to prime number total
+            assert!(
+                rounding_error > 0,
+                "Should have rounding error with prime total votes"
+            );
+
+            // Rounding error should be small (less than number of farms)
+            assert!(
+                rounding_error < 25,
+                "Rounding error should be less than number of farms"
+            );
+
+            // The rounding adjustment ensures no tokens are lost
+            assert_eq!(total_distributed + last_farm_emission, emission_rate);
+        })
+        .assert_ok();
+}
+
+#[test]
 fn test_single_user_vote_all_farms() {
-    // setup
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
     );
 
     let first_user = gov_setup.first_user.clone();
-    let farm_wm = gov_setup.farm_wm_wrapper.address_ref().clone();
-    let farm_wu = gov_setup.farm_wu_wrapper.address_ref().clone();
-    let farm_wh = gov_setup.farm_wh_wrapper.address_ref().clone();
+    let farm_0 = gov_setup.get_farm_address(0);
+    let farm_1 = gov_setup.get_farm_address(1);
+    let farm_2 = gov_setup.get_farm_address(2);
 
     // Set user energy - will split it between 3 farms
     let total_energy = 3_000u64;
@@ -83,9 +198,9 @@ fn test_single_user_vote_all_farms() {
 
     // Vote for all farms - 1000 energy each
     let votes = vec![
-        MultiValue2::from((farm_wm.clone(), 1_000u64)),
-        MultiValue2::from((farm_wu.clone(), 1_000u64)),
-        MultiValue2::from((farm_wh.clone(), 1_000u64)),
+        MultiValue2::from((farm_0.clone(), 1_000u64)),
+        MultiValue2::from((farm_1.clone(), 1_000u64)),
+        MultiValue2::from((farm_2.clone(), 1_000u64)),
     ];
     gov_setup.vote(first_user.clone(), votes).assert_ok();
 
@@ -97,25 +212,25 @@ fn test_single_user_vote_all_farms() {
             let next_week = current_week + 1;
 
             // Check all farms are in voted farms list
-            let farm_wm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wm));
-            let farm_wu_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wu));
-            let farm_wh_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wh));
+            let farm_0_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_0));
+            let farm_1_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_1));
+            let farm_2_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_2));
 
-            assert!(sc.voted_farms_for_week(next_week).contains(&farm_wm_id));
-            assert!(sc.voted_farms_for_week(next_week).contains(&farm_wu_id));
-            assert!(sc.voted_farms_for_week(next_week).contains(&farm_wh_id));
+            assert!(sc.voted_farms_for_week(next_week).contains(&farm_0_id));
+            assert!(sc.voted_farms_for_week(next_week).contains(&farm_1_id));
+            assert!(sc.voted_farms_for_week(next_week).contains(&farm_2_id));
 
             // Check individual vote amounts
             assert_eq!(
-                sc.farm_votes_for_week(farm_wm_id, next_week).get(),
+                sc.farm_votes_for_week(farm_0_id, next_week).get(),
                 managed_biguint!(1_000)
             );
             assert_eq!(
-                sc.farm_votes_for_week(farm_wu_id, next_week).get(),
+                sc.farm_votes_for_week(farm_1_id, next_week).get(),
                 managed_biguint!(1_000)
             );
             assert_eq!(
-                sc.farm_votes_for_week(farm_wh_id, next_week).get(),
+                sc.farm_votes_for_week(farm_2_id, next_week).get(),
                 managed_biguint!(1_000)
             );
 
@@ -130,9 +245,7 @@ fn test_single_user_vote_all_farms() {
 
 #[test]
 fn test_multiple_users_vote_multiple_farms() {
-    // setup
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
@@ -141,9 +254,9 @@ fn test_multiple_users_vote_multiple_farms() {
     let first_user = gov_setup.first_user.clone();
     let second_user = gov_setup.second_user.clone();
     let third_user = gov_setup.third_user.clone();
-    let farm_wm = gov_setup.farm_wm_wrapper.address_ref().clone();
-    let farm_wu = gov_setup.farm_wu_wrapper.address_ref().clone();
-    let farm_wh = gov_setup.farm_wh_wrapper.address_ref().clone();
+    let farm_0 = gov_setup.get_farm_address(0);
+    let farm_1 = gov_setup.get_farm_address(1);
+    let farm_2 = gov_setup.get_farm_address(2);
 
     // Set up energy for all users
     gov_setup.set_user_energy(first_user.clone(), 1_000, 1, 1_000);
@@ -152,24 +265,24 @@ fn test_multiple_users_vote_multiple_farms() {
 
     // First user votes for first two farms
     let first_user_votes = vec![
-        MultiValue2::from((farm_wm.clone(), 500u64)),
-        MultiValue2::from((farm_wu.clone(), 500u64)),
+        MultiValue2::from((farm_0.clone(), 500u64)),
+        MultiValue2::from((farm_1.clone(), 500u64)),
     ];
     gov_setup
         .vote(first_user.clone(), first_user_votes)
         .assert_ok();
 
-    // Second user votes for WEGLD-MEX and WEGLD-HTM
+    // Second user votes for farm 0 and farm 2
     let second_user_votes = vec![
-        MultiValue2::from((farm_wm.clone(), 500u64)),
-        MultiValue2::from((farm_wh.clone(), 500u64)),
+        MultiValue2::from((farm_0.clone(), 500u64)),
+        MultiValue2::from((farm_2.clone(), 500u64)),
     ];
     gov_setup
         .vote(second_user.clone(), second_user_votes)
         .assert_ok();
 
-    // Third user votes only for WEGLD-HTM
-    let third_user_votes = vec![MultiValue2::from((farm_wh.clone(), 1_000u64))];
+    // Third user votes only for farm 2
+    let third_user_votes = vec![MultiValue2::from((farm_2.clone(), 1_000u64))];
     gov_setup
         .vote(third_user.clone(), third_user_votes)
         .assert_ok();
@@ -181,21 +294,21 @@ fn test_multiple_users_vote_multiple_farms() {
             let current_week = sc.get_current_week();
             let next_week = current_week + 1;
 
-            let farm_wm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wm));
-            let farm_wu_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wu));
-            let farm_wh_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wh));
+            let farm_0_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_0));
+            let farm_1_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_1));
+            let farm_2_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_2));
 
             // Check vote amounts for each farm
             assert_eq!(
-                sc.farm_votes_for_week(farm_wm_id, next_week).get(),
+                sc.farm_votes_for_week(farm_0_id, next_week).get(),
                 managed_biguint!(1_000)
             ); // 500 from each of first two users
             assert_eq!(
-                sc.farm_votes_for_week(farm_wu_id, next_week).get(),
+                sc.farm_votes_for_week(farm_1_id, next_week).get(),
                 managed_biguint!(500)
             ); // 500 from first user
             assert_eq!(
-                sc.farm_votes_for_week(farm_wh_id, next_week).get(),
+                sc.farm_votes_for_week(farm_2_id, next_week).get(),
                 managed_biguint!(1_500)
             ); // 500 from second user + 1000 from third user
 
@@ -210,9 +323,7 @@ fn test_multiple_users_vote_multiple_farms() {
 
 #[test]
 fn test_incentivize_farm_and_claim_multiple_users() {
-    // setup
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
@@ -222,9 +333,9 @@ fn test_incentivize_farm_and_claim_multiple_users() {
     let first_user = gov_setup.first_user.clone();
     let second_user = gov_setup.second_user.clone();
     let third_user = gov_setup.third_user.clone();
-    let farm_wm = gov_setup.farm_wm_wrapper.address_ref().clone();
-    let farm_wu = gov_setup.farm_wu_wrapper.address_ref().clone();
-    let farm_wh = gov_setup.farm_wh_wrapper.address_ref().clone();
+    let farm_0 = gov_setup.get_farm_address(0);
+    let farm_1 = gov_setup.get_farm_address(1);
+    let farm_2 = gov_setup.get_farm_address(2);
 
     // Add MEX tokens to owner for incentives
     gov_setup
@@ -232,38 +343,38 @@ fn test_incentivize_farm_and_claim_multiple_users() {
         .set_esdt_balance(&owner, MEX_TOKEN_ID, &rust_biguint!(1_000_000));
 
     // Set up energy for all users
-    gov_setup.set_user_energy(first_user.clone(), 2_000, 1, 2_000); // votes for WM, WU
-    gov_setup.set_user_energy(second_user.clone(), 2_000, 1, 2_000); // votes for WM, WH
-    gov_setup.set_user_energy(third_user.clone(), 1_000, 1, 1_000); // votes only for WH
+    gov_setup.set_user_energy(first_user.clone(), 2_000, 1, 2_000);
+    gov_setup.set_user_energy(second_user.clone(), 2_000, 1, 2_000);
+    gov_setup.set_user_energy(third_user.clone(), 1_000, 1, 1_000);
 
-    // First user votes for WEGLD-MEX and WEGLD-USDC
+    // First user votes for farm 0 and farm 1
     let first_user_votes = vec![
-        MultiValue2::from((farm_wm.clone(), 1_000u64)),
-        MultiValue2::from((farm_wu.clone(), 1_000u64)),
+        MultiValue2::from((farm_0.clone(), 1_000u64)),
+        MultiValue2::from((farm_1.clone(), 1_000u64)),
     ];
     gov_setup
         .vote(first_user.clone(), first_user_votes)
         .assert_ok();
 
-    // Second user votes for WEGLD-MEX and WEGLD-HTM
+    // Second user votes for farm 0 and farm 2
     let second_user_votes = vec![
-        MultiValue2::from((farm_wm.clone(), 1_000u64)),
-        MultiValue2::from((farm_wh.clone(), 1_000u64)),
+        MultiValue2::from((farm_0.clone(), 1_000u64)),
+        MultiValue2::from((farm_2.clone(), 1_000u64)),
     ];
     gov_setup
         .vote(second_user.clone(), second_user_votes)
         .assert_ok();
 
-    // Third user votes entirely for WEGLD-HTM farm
-    let third_user_votes = vec![MultiValue2::from((farm_wh.clone(), 1_000u64))];
+    // Third user votes entirely for farm 2
+    let third_user_votes = vec![MultiValue2::from((farm_2.clone(), 1_000u64))];
     gov_setup
         .vote(third_user.clone(), third_user_votes)
         .assert_ok();
 
-    // Owner adds incentives for the WEGLD-HTM farm
+    // Owner adds incentives for farm 2
     let incentive_amount = 10_000u64;
     gov_setup
-        .incentivize_farm(farm_wh.clone(), owner.clone(), incentive_amount, 2)
+        .incentivize_farm(farm_2.clone(), owner.clone(), incentive_amount, 2)
         .assert_ok();
 
     // Advance epochs to week 3
@@ -281,7 +392,7 @@ fn test_incentivize_farm_and_claim_multiple_users() {
         .assert_ok();
 
     // Check users received correct incentives
-    // First user should have 0 (didn't vote for HTM farm)
+    // First user should have 0 (didn't vote for farm 2)
     gov_setup
         .b_mock
         .check_esdt_balance(&first_user, MEX_TOKEN_ID, &rust_biguint!(0));
@@ -301,9 +412,9 @@ fn test_incentivize_farm_and_claim_multiple_users() {
     gov_setup
         .b_mock
         .execute_query(&gov_setup.gov_wrapper, |sc| {
-            let farm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wh));
+            let farm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_2));
 
-            // Check total HTM farm votes (should be 2000 - 1000 each from users 2 and 3)
+            // Check total farm 2 votes (should be 2000 - 1000 each from users 2 and 3)
             assert_eq!(
                 sc.farm_votes_for_week(farm_id, 2).get(),
                 managed_biguint!(2_000)
@@ -315,7 +426,6 @@ fn test_incentivize_farm_and_claim_multiple_users() {
 #[test]
 fn test_change_emission_rate_and_distributions() {
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
@@ -324,16 +434,16 @@ fn test_change_emission_rate_and_distributions() {
     let owner = gov_setup.owner.clone();
     let first_user = gov_setup.first_user.clone();
     let second_user = gov_setup.second_user.clone();
-    let farm_wm = gov_setup.farm_wm_wrapper.address_ref().clone();
-    let farm_wu = gov_setup.farm_wu_wrapper.address_ref().clone();
+    let farm_0 = gov_setup.get_farm_address(0);
+    let farm_1 = gov_setup.get_farm_address(1);
 
     // Set up energy for users
     gov_setup.set_user_energy(first_user.clone(), 1_000, 1, 1_000);
     gov_setup.set_user_energy(second_user.clone(), 1_000, 1, 1_000);
 
     // Users vote in week 1
-    let first_user_votes = vec![MultiValue2::from((farm_wm.clone(), 1_000u64))];
-    let second_user_votes = vec![MultiValue2::from((farm_wu.clone(), 1_000u64))];
+    let first_user_votes = vec![MultiValue2::from((farm_0.clone(), 1_000u64))];
+    let second_user_votes = vec![MultiValue2::from((farm_1.clone(), 1_000u64))];
 
     gov_setup
         .vote(first_user.clone(), first_user_votes.clone())
@@ -389,7 +499,6 @@ fn test_change_emission_rate_and_distributions() {
 #[test]
 fn test_blacklist_farm_with_active_votes() {
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
@@ -399,7 +508,7 @@ fn test_blacklist_farm_with_active_votes() {
     let first_user = gov_setup.first_user.clone();
     let second_user = gov_setup.second_user.clone();
     let third_user = gov_setup.third_user.clone();
-    let farm_wh = gov_setup.farm_wh_wrapper.address_ref().clone();
+    let farm_2 = gov_setup.get_farm_address(2);
 
     // Add MEX tokens for incentives
     gov_setup
@@ -412,9 +521,9 @@ fn test_blacklist_farm_with_active_votes() {
     gov_setup.set_user_energy(third_user.clone(), 1_000, 1, 1_000);
 
     // Users vote for the farm that will be blacklisted
-    let first_user_votes = vec![MultiValue2::from((farm_wh.clone(), 1_000u64))];
-    let second_user_votes = vec![MultiValue2::from((farm_wh.clone(), 1_000u64))];
-    let third_user_votes = vec![MultiValue2::from((farm_wh.clone(), 1_000u64))];
+    let first_user_votes = vec![MultiValue2::from((farm_2.clone(), 1_000u64))];
+    let second_user_votes = vec![MultiValue2::from((farm_2.clone(), 1_000u64))];
+    let third_user_votes = vec![MultiValue2::from((farm_2.clone(), 1_000u64))];
 
     gov_setup
         .vote(first_user.clone(), first_user_votes)
@@ -426,17 +535,17 @@ fn test_blacklist_farm_with_active_votes() {
     // Add incentives for the farm
     let incentive_amount = 10_000u64;
     gov_setup
-        .incentivize_farm(farm_wh.clone(), owner.clone(), incentive_amount, 2)
+        .incentivize_farm(farm_2.clone(), owner.clone(), incentive_amount, 2)
         .assert_ok();
 
     // Owner blacklists the farm
-    gov_setup.blacklist_farm(farm_wh.clone()).assert_ok();
+    gov_setup.blacklist_farm(farm_2.clone()).assert_ok();
 
     // Verify the blacklisted state
     gov_setup
         .b_mock
         .execute_query(&gov_setup.gov_wrapper, |sc| {
-            let farm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_wh));
+            let farm_id = sc.farm_ids().get_id_non_zero(&managed_address!(&farm_2));
 
             // Check farm is blacklisted
             assert!(sc.blacklisted_farms().contains(&farm_id));
@@ -451,9 +560,7 @@ fn test_blacklist_farm_with_active_votes() {
 
 #[test]
 fn test_set_farm_emissions() {
-    // Setup
     let mut gov_setup = GovSetup::new(
-        pair::contract_obj,
         farm_with_locked_rewards::contract_obj,
         energy_factory::contract_obj,
         mex_governance::contract_obj,
@@ -461,27 +568,27 @@ fn test_set_farm_emissions() {
 
     let first_user = gov_setup.first_user.clone();
     let second_user = gov_setup.second_user.clone();
-    let farm_wm = gov_setup.farm_wm_wrapper.address_ref().clone();
-    let farm_wu = gov_setup.farm_wu_wrapper.address_ref().clone();
-    let farm_wh = gov_setup.farm_wh_wrapper.address_ref().clone();
+    let farm_0 = gov_setup.get_farm_address(0);
+    let farm_1 = gov_setup.get_farm_address(1);
+    let farm_2 = gov_setup.get_farm_address(2);
 
     // Set up energy for users
     gov_setup.set_user_energy(first_user.clone(), 6_000, 1, 6_000);
     gov_setup.set_user_energy(second_user.clone(), 4_000, 1, 4_000);
 
     // Users vote with different distributions to test proportional allocation
-    // First user: 6000 total energy - 3000 to WM, 2000 to WU, 1000 to WH
+    // First user: 6000 total energy - 3000 to farm 0, 2000 to farm 1, 1000 to farm 2
     let first_user_votes = vec![
-        MultiValue2::from((farm_wm.clone(), 3_000u64)),
-        MultiValue2::from((farm_wu.clone(), 2_000u64)),
-        MultiValue2::from((farm_wh.clone(), 1_000u64)),
+        MultiValue2::from((farm_0.clone(), 3_000u64)),
+        MultiValue2::from((farm_1.clone(), 2_000u64)),
+        MultiValue2::from((farm_2.clone(), 1_000u64)),
     ];
 
-    // Second user: 4000 total energy - 1000 to WM, 1000 to WU, 2000 to WH
+    // Second user: 4000 total energy - 1000 to farm 0, 1000 to farm 1, 2000 to farm 2
     let second_user_votes = vec![
-        MultiValue2::from((farm_wm.clone(), 1_000u64)),
-        MultiValue2::from((farm_wu.clone(), 1_000u64)),
-        MultiValue2::from((farm_wh.clone(), 2_000u64)),
+        MultiValue2::from((farm_0.clone(), 1_000u64)),
+        MultiValue2::from((farm_1.clone(), 1_000u64)),
+        MultiValue2::from((farm_2.clone(), 2_000u64)),
     ];
 
     // Submit votes
@@ -496,59 +603,51 @@ fn test_set_farm_emissions() {
     gov_setup.b_mock.set_block_epoch(10);
     gov_setup.b_mock.set_block_nonce(100);
 
-    // Now we need to call set_farm_emissions - we'll add this method to our setup
-    gov_setup
-        .b_mock
-        .execute_tx(
-            &gov_setup.owner,
-            &gov_setup.gov_wrapper,
-            &rust_biguint!(0),
-            |sc| {
-                sc.set_farm_emissions();
-            },
-        )
-        .assert_ok();
+    // Call set_farm_emissions
+    gov_setup.set_farm_emissions().assert_ok();
 
     // Verify each farm has correct per_block_rewards set
     // Total energy voted: 10,000
-    // Farm WM: 4,000 votes (40% of total)
-    // Farm WU: 3,000 votes (30% of total)
-    // Farm WH: 3,000 votes (30% of total)
+    // Farm 0: 4,000 votes (40% of total)
+    // Farm 1: 3,000 votes (30% of total)
+    // Farm 2: 3,000 votes (30% of total)
 
     // With DEFAULT_EMISSION_RATE = 10,000
     // Expected rewards:
-    // Farm WM: 10,000 * 0.4 = 4,000
-    // Farm WU: 10,000 * 0.3 = 3,000
-    // Farm WH: 10,000 * 0.3 = 3,000
+    // Farm 0: 10,000 * 0.4 = 4,000
+    // Farm 1: 10,000 * 0.3 = 3,000
+    // Farm 2: 10,000 * 0.3 = 3,000
 
-    // Check farm WM rewards
+    // Check farm 0 rewards
+    let farm_0_wrapper = &gov_setup.farm_wrappers[0];
     gov_setup
         .b_mock
-        .execute_query(&gov_setup.farm_wm_wrapper, |sc| {
+        .execute_query(farm_0_wrapper, |sc| {
             let per_block_rewards = sc.per_block_reward_amount().get();
             assert_eq!(per_block_rewards, managed_biguint!(4_000));
         })
         .assert_ok();
 
-    // Check farm WU rewards
+    // Check farm 1 rewards
+    let farm_1_wrapper = &gov_setup.farm_wrappers[1];
     gov_setup
         .b_mock
-        .execute_query(&gov_setup.farm_wu_wrapper, |sc| {
+        .execute_query(farm_1_wrapper, |sc| {
             let per_block_rewards = sc.per_block_reward_amount().get();
             assert_eq!(per_block_rewards, managed_biguint!(3_000));
         })
         .assert_ok();
 
-    // Check farm WH rewards
+    // Check farm 2 rewards
+    let farm_2_wrapper = &gov_setup.farm_wrappers[2];
     gov_setup
         .b_mock
-        .execute_query(&gov_setup.farm_wh_wrapper, |sc| {
+        .execute_query(farm_2_wrapper, |sc| {
             let per_block_rewards = sc.per_block_reward_amount().get();
             assert_eq!(per_block_rewards, managed_biguint!(3_000));
         })
         .assert_ok();
 
-    // Now let's test with a changed emission rate
     // Update emission rate for next week
     gov_setup
         .b_mock
@@ -578,47 +677,519 @@ fn test_set_farm_emissions() {
     gov_setup.b_mock.set_block_nonce(200);
 
     // Call set_farm_emissions again
-    gov_setup
-        .b_mock
-        .execute_tx(
-            &gov_setup.owner,
-            &gov_setup.gov_wrapper,
-            &rust_biguint!(0),
-            |sc| {
-                sc.set_farm_emissions();
-            },
-        )
-        .assert_ok();
+    gov_setup.set_farm_emissions().assert_ok();
 
     // With new emission rate of 20,000, expect doubled rewards
-    // Farm WM: 20,000 * 0.4 = 8,000
-    // Farm WU: 20,000 * 0.3 = 6,000
-    // Farm WH: 20,000 * 0.3 = 6,000
+    // Farm 0: 20,000 * 0.4 = 8,000
+    // Farm 1: 20,000 * 0.3 = 6,000
+    // Farm 2: 20,000 * 0.3 = 6,000
 
-    // Check farm WM rewards with new rate
+    // Check farm 0 rewards with new rate
+    let farm_0_wrapper = &gov_setup.farm_wrappers[0];
     gov_setup
         .b_mock
-        .execute_query(&gov_setup.farm_wm_wrapper, |sc| {
+        .execute_query(farm_0_wrapper, |sc| {
             let per_block_rewards = sc.per_block_reward_amount().get();
             assert_eq!(per_block_rewards, managed_biguint!(8_000));
         })
         .assert_ok();
 
-    // Check farm WU rewards with new rate
+    // Check farm 1 rewards with new rate
+    let farm_1_wrapper = &gov_setup.farm_wrappers[1];
     gov_setup
         .b_mock
-        .execute_query(&gov_setup.farm_wu_wrapper, |sc| {
+        .execute_query(farm_1_wrapper, |sc| {
             let per_block_rewards = sc.per_block_reward_amount().get();
             assert_eq!(per_block_rewards, managed_biguint!(6_000));
         })
         .assert_ok();
 
-    // Check farm WH rewards with new rate
+    // Check farm 2 rewards with new rate
+    let farm_2_wrapper = &gov_setup.farm_wrappers[2];
     gov_setup
         .b_mock
-        .execute_query(&gov_setup.farm_wh_wrapper, |sc| {
+        .execute_query(farm_2_wrapper, |sc| {
             let per_block_rewards = sc.per_block_reward_amount().get();
             assert_eq!(per_block_rewards, managed_biguint!(6_000));
+        })
+        .assert_ok();
+}
+
+#[test]
+fn test_edge_case_all_votes_outside_top_25() {
+    // Setup with 30 farms
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        30,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    let second_user = gov_setup.second_user.clone();
+    let third_user = gov_setup.third_user.clone();
+    let fourth_user = gov_setup.b_mock.create_user_account(&rust_biguint!(0));
+
+    // Set up energy for users
+    gov_setup.set_user_energy(first_user.clone(), 40_000, 1, 40_000);
+    gov_setup.set_user_energy(second_user.clone(), 40_000, 1, 40_000);
+    gov_setup.set_user_energy(third_user.clone(), 20_000, 1, 20_000);
+    gov_setup.set_user_energy(fourth_user.clone(), 10_000, 1, 10_000);
+
+    // First user votes for farms 0-9 (10 farms max)
+    let mut first_user_votes = vec![];
+    for i in 0..10 {
+        first_user_votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup
+        .vote(first_user.clone(), first_user_votes)
+        .assert_ok();
+
+    // Second user votes for farms 10-19
+    let mut second_user_votes = vec![];
+    for i in 10..20 {
+        second_user_votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup
+        .vote(second_user.clone(), second_user_votes)
+        .assert_ok();
+
+    // Third user votes for farms 20-24 to complete top 25
+    let mut third_user_votes = vec![];
+    for i in 20..25 {
+        third_user_votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup
+        .vote(third_user.clone(), third_user_votes)
+        .assert_ok();
+
+    // Fourth user votes only for farms 25-29 with small amounts
+    // These votes will all be redistributed because farms 25-29 won't make it to top 25
+    let mut fourth_user_votes = vec![];
+    for i in 25..30 {
+        fourth_user_votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 2_000u64)));
+    }
+    gov_setup
+        .vote(fourth_user.clone(), fourth_user_votes)
+        .assert_ok();
+
+    // Verify state
+    gov_setup
+        .b_mock
+        .execute_query(&gov_setup.gov_wrapper, |sc| {
+            let voting_week = 2;
+
+            // Top 25 should be farms 0-24 (each with 4000 votes)
+            let farm_emissions = sc.farm_emissions_for_week(voting_week).get();
+            assert_eq!(farm_emissions.len(), 25, "Should have exactly 25 farms");
+
+            // All of fourth user's votes (10,000 total) should be redistributed
+            let redistributed = sc.redistributed_votes_for_week(voting_week).get();
+            assert_eq!(redistributed, managed_biguint!(10_000));
+
+            // Verify farms 0-24 are in the list with 4000 votes each
+            for emission in farm_emissions.iter() {
+                assert_eq!(emission.farm_emission, managed_biguint!(4_000));
+            }
+        })
+        .assert_ok();
+
+    // Advance to next week
+    gov_setup.b_mock.set_block_epoch(10);
+
+    // This should now work correctly - no division by zero because top farms have votes
+    gov_setup.set_farm_emissions().assert_ok();
+}
+
+#[test]
+fn test_division_by_zero_when_all_votes_redistributed() {
+    // This test demonstrates the division by zero issue
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        30,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    gov_setup.set_user_energy(first_user.clone(), 10_000, 1, 10_000);
+
+    // Vote only for farms outside top 25
+    let mut votes = vec![];
+    for i in 25..30 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 2_000u64)));
+    }
+
+    gov_setup.vote(first_user.clone(), votes).assert_ok();
+
+    // Advance to next week and set emissions
+    gov_setup.b_mock.set_block_epoch(10);
+
+    // This should cause issues because top_farms_total_votes = 0
+    // In the current implementation, this would cause a division by zero
+    gov_setup.set_farm_emissions().assert_ok();
+}
+
+#[test]
+fn test_less_than_25_farms_no_redistribution() {
+    // Setup with only 10 farms (less than MAX_REWARDED_FARMS)
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        10,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    gov_setup.set_user_energy(first_user.clone(), 10_000, 1, 10_000);
+
+    // Vote for all 10 farms
+    let mut votes = vec![];
+    for i in 0..10 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+
+    gov_setup.vote(first_user.clone(), votes).assert_ok();
+
+    // Verify no redistribution occurs
+    gov_setup
+        .b_mock
+        .execute_query(&gov_setup.gov_wrapper, |sc| {
+            let voting_week = 2;
+
+            // All farms should be in top farms
+            let farm_emissions = sc.farm_emissions_for_week(voting_week).get();
+            assert_eq!(farm_emissions.len(), 10);
+
+            // No redistribution should occur
+            let redistributed = sc.redistributed_votes_for_week(voting_week).get();
+            assert_eq!(redistributed, managed_biguint!(0));
+        })
+        .assert_ok();
+
+    // Advance and set emissions
+    gov_setup.b_mock.set_block_epoch(10);
+    gov_setup.set_farm_emissions().assert_ok();
+
+    // Verify each farm gets exact proportional share
+    let farm_0_wrapper = &gov_setup.farm_wrappers[0];
+    gov_setup
+        .b_mock
+        .execute_query(farm_0_wrapper, |sc| {
+            let per_block_rewards = sc.per_block_reward_amount().get();
+            // Each farm has 1000 votes out of 10000 total = 10%
+            // 10% of 10000 emission rate = 1000
+            assert_eq!(per_block_rewards, managed_biguint!(1_000));
+        })
+        .assert_ok();
+}
+
+#[test]
+fn test_farm_ranking_changes_between_weeks() {
+    // Test that farm rankings can change between voting weeks
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        30,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    let second_user = gov_setup.second_user.clone();
+    let third_user = gov_setup.third_user.clone();
+
+    // Week 1: Set up energy
+    gov_setup.set_user_energy(first_user.clone(), 40_000, 1, 40_000);
+    gov_setup.set_user_energy(second_user.clone(), 40_000, 1, 40_000);
+    gov_setup.set_user_energy(third_user.clone(), 20_000, 1, 20_000);
+
+    // Week 1 votes: Farm 25 is outside top 25
+    // First user: farms 0-9
+    let mut week1_votes_user1 = vec![];
+    for i in 0..10 {
+        week1_votes_user1.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup
+        .vote(first_user.clone(), week1_votes_user1)
+        .assert_ok();
+
+    // Second user: farms 10-19
+    let mut week1_votes_user2 = vec![];
+    for i in 10..20 {
+        week1_votes_user2.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup
+        .vote(second_user.clone(), week1_votes_user2)
+        .assert_ok();
+
+    // Third user: farms 20-24
+    let mut week1_votes_user3 = vec![];
+    for i in 20..25 {
+        week1_votes_user3.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup
+        .vote(third_user.clone(), week1_votes_user3)
+        .assert_ok();
+
+    // Verify farm 25 is not in top 25
+    let farm_25_address = gov_setup.get_farm_address(25);
+    gov_setup
+        .b_mock
+        .execute_query(&gov_setup.gov_wrapper, |sc| {
+            let voting_week = 2;
+            let farm_emissions = sc.farm_emissions_for_week(voting_week).get();
+
+            // Farm 25 should not be in the list
+            let farm_25_managed = managed_address!(&farm_25_address);
+            let mut found_farm_25 = false;
+            for emission in farm_emissions.iter() {
+                if emission.farm_address == farm_25_managed {
+                    found_farm_25 = true;
+                    break;
+                }
+            }
+            assert!(!found_farm_25, "Farm 25 should not be in top 25 in week 1");
+        })
+        .assert_ok();
+
+    // Advance to week 2
+    gov_setup.b_mock.set_block_epoch(10);
+
+    // Week 2: Different voting pattern - Farm 25 gets massive votes
+    gov_setup.set_user_energy(first_user.clone(), 35_000, 10, 35_000);
+    gov_setup.set_user_energy(second_user.clone(), 35_000, 10, 35_000);
+    gov_setup.set_user_energy(third_user.clone(), 30_000, 10, 30_000);
+
+    // All users vote heavily for farm 25
+    let mut week2_votes_user1 = vec![];
+    week2_votes_user1.push(MultiValue2::from((farm_25_address.clone(), 30_000u64)));
+    for i in 0..5 {
+        week2_votes_user1.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup
+        .vote(first_user.clone(), week2_votes_user1)
+        .assert_ok();
+
+    let mut week2_votes_user2 = vec![];
+    week2_votes_user2.push(MultiValue2::from((farm_25_address.clone(), 30_000u64)));
+    for i in 5..10 {
+        week2_votes_user2.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup
+        .vote(second_user.clone(), week2_votes_user2)
+        .assert_ok();
+
+    let mut week2_votes_user3 = vec![];
+    week2_votes_user3.push(MultiValue2::from((farm_25_address.clone(), 20_000u64)));
+    for i in 10..18 {
+        week2_votes_user3.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_111u64)));
+    }
+    // Last farm gets the remainder to make it exactly 30,000
+    week2_votes_user3.push(MultiValue2::from((
+        gov_setup.get_farm_address(18),
+        1_112u64,
+    )));
+    gov_setup
+        .vote(third_user.clone(), week2_votes_user3)
+        .assert_ok();
+
+    // Verify farm 25 is now in top 25 (actually should be #1)
+    gov_setup
+        .b_mock
+        .execute_query(&gov_setup.gov_wrapper, |sc| {
+            let voting_week = 3;
+            let farm_emissions = sc.farm_emissions_for_week(voting_week).get();
+
+            // Farm 25 should be first with 80,000 votes
+            let first_farm = farm_emissions.get(0);
+            let farm_25_managed = managed_address!(&farm_25_address);
+            assert_eq!(first_farm.farm_address, farm_25_managed);
+            assert_eq!(first_farm.farm_emission, managed_biguint!(80_000));
+        })
+        .assert_ok();
+}
+
+#[test]
+fn test_exactly_25_farms_with_votes() {
+    // Test when exactly 25 farms receive votes
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        30,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    let second_user = gov_setup.second_user.clone();
+    let third_user = gov_setup.third_user.clone();
+
+    gov_setup.set_user_energy(first_user.clone(), 10_000, 1, 10_000);
+    gov_setup.set_user_energy(second_user.clone(), 10_000, 1, 10_000);
+    gov_setup.set_user_energy(third_user.clone(), 5_000, 1, 5_000);
+
+    // First user votes for farms 0-9
+    let mut votes = vec![];
+    for i in 0..10 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup.vote(first_user.clone(), votes).assert_ok();
+
+    // Second user votes for farms 10-19
+    let mut votes = vec![];
+    for i in 10..20 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup.vote(second_user.clone(), votes).assert_ok();
+
+    // Third user votes for farms 20-24
+    let mut votes = vec![];
+    for i in 20..25 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup.vote(third_user.clone(), votes).assert_ok();
+
+    // Verify state
+    gov_setup
+        .b_mock
+        .execute_query(&gov_setup.gov_wrapper, |sc| {
+            let voting_week = 2;
+
+            // Exactly 25 farms in emissions
+            let farm_emissions = sc.farm_emissions_for_week(voting_week).get();
+            assert_eq!(farm_emissions.len(), 25);
+
+            // No redistribution
+            let redistributed = sc.redistributed_votes_for_week(voting_week).get();
+            assert_eq!(redistributed, managed_biguint!(0));
+
+            // All farms should have equal votes
+            for emission in farm_emissions.iter() {
+                assert_eq!(emission.farm_emission, managed_biguint!(1_000));
+            }
+        })
+        .assert_ok();
+
+    // Set emissions
+    gov_setup.b_mock.set_block_epoch(10);
+    gov_setup.set_farm_emissions().assert_ok();
+
+    // Each farm should get exactly 1/25 of total emissions
+    let expected_per_farm = DEFAULT_EMISSION_RATE / 25; // 10,000 / 25 = 400
+
+    let farm_0_wrapper = &gov_setup.farm_wrappers[0];
+    gov_setup
+        .b_mock
+        .execute_query(farm_0_wrapper, |sc| {
+            let per_block_rewards = sc.per_block_reward_amount().get();
+            assert_eq!(per_block_rewards, managed_biguint!(expected_per_farm));
+        })
+        .assert_ok();
+}
+
+#[test]
+fn test_tied_votes_at_boundary() {
+    // Test when multiple farms have the same votes around the 25th position
+    let mut gov_setup = GovSetup::new_with_farms(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+        mex_governance::contract_obj,
+        30,
+    );
+
+    let first_user = gov_setup.first_user.clone();
+    let second_user = gov_setup.second_user.clone();
+    let third_user = gov_setup.third_user.clone();
+    let fourth_user = gov_setup.b_mock.create_user_account(&rust_biguint!(0));
+
+    gov_setup.set_user_energy(first_user.clone(), 40_000, 1, 40_000);
+    gov_setup.set_user_energy(second_user.clone(), 40_000, 1, 40_000);
+    gov_setup.set_user_energy(third_user.clone(), 10_000, 1, 10_000);
+    gov_setup.set_user_energy(fourth_user.clone(), 10_000, 1, 10_000);
+
+    let mut votes = vec![];
+
+    // First user: Farms 0-9: 4000 votes each (40,000 total)
+    for i in 0..10 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup.vote(first_user.clone(), votes).assert_ok();
+
+    // Second user: Farms 10-19: 4000 votes each (40,000 total)
+    let mut votes = vec![];
+    for i in 10..20 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 4_000u64)));
+    }
+    gov_setup.vote(second_user.clone(), votes).assert_ok();
+
+    // Third user: Farms 20-29: 1000 votes each (10,000 total) - tied at boundary
+    let mut votes = vec![];
+    for i in 20..30 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup.vote(third_user.clone(), votes).assert_ok();
+
+    // Fourth user also votes for some of the boundary farms to create more ties
+    let mut votes = vec![];
+    for i in 18..28 {
+        votes.push(MultiValue2::from((gov_setup.get_farm_address(i), 1_000u64)));
+    }
+    gov_setup.vote(fourth_user.clone(), votes).assert_ok();
+
+    // Verify how ties are handled
+    gov_setup
+        .b_mock
+        .execute_query(&gov_setup.gov_wrapper, |sc| {
+            let voting_week = 2;
+            let farm_emissions = sc.farm_emissions_for_week(voting_week).get();
+
+            // Should have 25 farms
+            assert_eq!(farm_emissions.len(), 25);
+
+            // Count redistributed votes
+            let redistributed = sc.redistributed_votes_for_week(voting_week).get();
+
+            // Verify sorting is consistent
+            for i in 0..farm_emissions.len() - 1 {
+                let current = &farm_emissions.get(i);
+                let next = &farm_emissions.get(i + 1);
+                assert!(
+                    current.farm_emission >= next.farm_emission,
+                    "Farms should be sorted in descending order"
+                );
+            }
+
+            // Expected votes:
+            // Farms 0-17: 4000 votes each
+            // Farms 18-19: 5000 votes (4000 + 1000)
+            // Farms 20-27: 2000 votes (1000 + 1000)
+            // Farms 28-29: 1000 votes
+
+            // After sorting, the order should be:
+            // Position 0-1: Farms 18-19 with 5000 votes
+            // Position 2-19: Farms 0-17 with 4000 votes
+            // Position 20-24: Five farms from 20-27 with 2000 votes
+
+            // Check first two positions (5000 votes)
+            for i in 0..2 {
+                let emission = farm_emissions.get(i);
+                assert_eq!(emission.farm_emission, managed_biguint!(5_000));
+            }
+
+            // Check positions 2-19 (4000 votes)
+            for i in 2..20 {
+                let emission = farm_emissions.get(i);
+                assert_eq!(emission.farm_emission, managed_biguint!(4_000));
+            }
+
+            // Check positions 20-24 (2000 votes)
+            for i in 20..25 {
+                let emission = farm_emissions.get(i);
+                assert_eq!(emission.farm_emission, managed_biguint!(2_000));
+            }
+
+            // Three farms with 2000 votes and two farms with 1000 votes should be outside top 25
+            // So redistributed = 3*2000 + 2*1000 = 8000
+            assert_eq!(redistributed, managed_biguint!(8_000));
         })
         .assert_ok();
 }

--- a/energy-integration/mex-governance/wasm/src/lib.rs
+++ b/energy-integration/mex-governance/wasm/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           13
+// Endpoints:                           14
 // Async Callback (empty):               1
-// Total number of exported functions:  16
+// Total number of exported functions:  17
 
 #![no_std]
 
@@ -24,6 +24,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         removeBlacklistFarm => remove_blacklist_farm
         setReferenceEmissionRate => set_reference_emission_rate
         setIncentiveToken => set_incentive_token
+        resetFarmEmissions => reset_farm_emissions
         setFarmEmissions => set_farm_emissions
         incentivizeFarm => incentivize_farm
         claimIncentive => claim_incentive


### PR DESCRIPTION
Added MEX Governance top farms functionality:
- Only the top 25 farms by vote count receive emissions, ensuring rewards focus on the most popular farms
- Votes for farms beyond the top 25 are proportionally redistributed to the top farms.
- Implemented selection sort algorithm to keep the top farms list updated in realtime with each transaction.
- Previous week's farm emissions are automatically reset to zero before applying new emissions.
- The emissions of the farms are stored for each week and can be updated weekly.