### PR TITLE
Claim developer rewards endpoint in router (#1029) (#1034)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,7 +22,7 @@ jobs:
     name: Contracts
     uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v4.2.2
     with:
-      rust-toolchain: stable
+      rust-toolchain: 1.86
       coverage-args: --ignore-filename-regex='/.cargo/git' --output ./coverage.md
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: multiversx/mx-sc-actions/.github/workflows/reproducible-build.yml@v4.2.2
     with:
-      image_tag: v7.0.0
+      image_tag: v10.0.0
       attach_to_existing_release: true

--- a/dex/router/wasm/src/lib.rs
+++ b/dex/router/wasm/src/lib.rs
@@ -6,9 +6,9 @@
 
 // Init:                                 1
 // Upgrade:                              1
-// Endpoints:                           29
+// Endpoints:                           30
 // Async Callback:                       1
-// Total number of exported functions:  32
+// Total number of exported functions:  33
 
 #![no_std]
 
@@ -29,6 +29,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         removePair => remove_pair
         setFeeOn => set_fee_on
         setFeeOff => set_fee_off
+        claimDeveloperRewardsPairs => claim_developer_rewards_pairs
         setPairCreationEnabled => set_pair_creation_enabled
         getPairCreationEnabled => pair_creation_enabled
         getState => state


### PR DESCRIPTION
* Claim developer rewards endpoint in router (#1029)

* Claim developer rewards endpoint in router

* change claim developer rewards endpoint logic

* split claim developer rewards in 2 txs

* revert to one endpoint logic, after protocol upgrade

* github actions fix

* extra check

* Router claim developer rewards spacing fix (#1037)